### PR TITLE
vm compile: print partial-failure errors and exit 1

### DIFF
--- a/src/vaultmind/ai/compiler.py
+++ b/src/vaultmind/ai/compiler.py
@@ -165,13 +165,22 @@ async def compile_sources(
             log.info("compile_article_done", slug=target_slug, status="created_new")
             return (slug, target_slug, True, False)
 
+    async def _process_concept_with_error_handling(
+        concept: WikiConceptEntry,
+    ) -> tuple[str, str, bool, bool] | None:
+        """Wrap _process_concept to attach concept name to any exceptions."""
+        try:
+            return await _process_concept(concept)
+        except Exception as exc:
+            result.errors.append(f"Concept '{concept.name}' failed: {exc}")
+            return None
+
     processed = await asyncio.gather(
-        *[_process_concept(c) for c in concepts], return_exceptions=True
+        *[_process_concept_with_error_handling(c) for c in concepts], return_exceptions=False
     )
 
     for item in processed:
-        if isinstance(item, BaseException):
-            result.errors.append(f"Concept processing failed: {item}")
+        if item is None:
             continue
         slug, target_slug, was_created, was_updated = item
         result.articles_created += was_created

--- a/src/vaultmind/commands/compile.py
+++ b/src/vaultmind/commands/compile.py
@@ -112,12 +112,20 @@ def compile(
     if result.articles_created > 0 or result.articles_updated > 0:
         _rebuild_wiki_index(config, manifest, provider)
 
-    print_success(
-        "Compile complete",
-        f"{result.articles_created} created, "
-        f"{result.articles_updated} updated, "
-        f"{result.sources_compiled} sources processed."
-    )
+    # Print success unless we're in full-failure case (no creations, no updates, but errors exist)
+    if not (result.articles_created == 0 and result.articles_updated == 0 and result.errors):
+        print_success(
+            "Compile complete",
+            f"{result.articles_created} created, "
+            f"{result.articles_updated} updated, "
+            f"{result.sources_compiled} sources processed."
+        )
+
+    # Print errors and exit non-zero if any occurred
+    if result.errors:
+        for error in result.errors:
+            print_warning(error)
+        raise typer.Exit(1)
 
 
 async def _run_compile_async(

--- a/tests/test_commands/test_compile.py
+++ b/tests/test_commands/test_compile.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from pathlib import Path
 
+import typer
+
+from vaultmind.commands import compile as compile_cmd
 from vaultmind.core.raw_scanner import RawSourceRecord
 from vaultmind.schemas import Manifest
 
@@ -123,3 +127,201 @@ def test_render_dry_run_summary_includes_sources_and_targets():
     assert "raw-a [Clippings/raw-a]" in summary
     assert "→ concept-a" in summary
     assert "Clippings/raw-a" in summary
+
+
+def test_compile_exits_nonzero_when_errors_present(monkeypatch, test_config):
+    """When compile result has errors, exit with code 1 and print warnings."""
+    source = _raw_source(slug="raw-a", source_url=None)
+    warnings_printed = []
+    captured_exit_code = None
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "read_manifest", lambda vault_path: Manifest())
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+
+    def capture_warning(message: str):
+        warnings_printed.append(message)
+
+    monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
+
+    async def fake_run(sources, manifest, config, provider, dry_run):
+        return (
+            compile_cmd.CompileResult(
+                articles_created=0,
+                articles_updated=0,
+                sources_compiled=len(sources),
+                errors=["Concept 'Test Concept' failed: TestError"],
+            ),
+            {},
+        )
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", fake_run)
+
+    def mock_exit(code: int):
+        nonlocal captured_exit_code
+        captured_exit_code = code
+        raise StopIteration(code)
+
+    monkeypatch.setattr(typer, "Exit", mock_exit)
+
+    with contextlib.suppress(StopIteration):
+        compile_cmd.compile(full=False, dry_run=False, verbose=False)
+
+    assert captured_exit_code == 1
+    assert len(warnings_printed) == 1
+    assert "Concept 'Test Concept' failed: TestError" in warnings_printed[0]
+
+
+def test_compile_prints_each_error_with_concept_name(monkeypatch, test_config):
+    """Each error in result.errors is printed via print_warning."""
+    source = _raw_source(slug="raw-a", source_url=None)
+    warnings_printed = []
+    captured_exit_code = None
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "read_manifest", lambda vault_path: Manifest())
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+
+    def capture_warning(message: str):
+        warnings_printed.append(message)
+
+    monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
+
+    async def fake_run(sources, manifest, config, provider, dry_run):
+        return (
+            compile_cmd.CompileResult(
+                articles_created=0,
+                articles_updated=0,
+                sources_compiled=len(sources),
+                errors=[
+                    "Concept 'Concept A' failed: error1",
+                    "Concept 'Concept B' failed: error2",
+                ],
+            ),
+            {},
+        )
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", fake_run)
+
+    def mock_exit(code: int):
+        nonlocal captured_exit_code
+        captured_exit_code = code
+        raise StopIteration(code)
+
+    monkeypatch.setattr(typer, "Exit", mock_exit)
+
+    with contextlib.suppress(StopIteration):
+        compile_cmd.compile(full=False, dry_run=False, verbose=False)
+
+    assert captured_exit_code == 1
+    assert len(warnings_printed) == 2
+    assert "Concept 'Concept A' failed: error1" in warnings_printed
+    assert "Concept 'Concept B' failed: error2" in warnings_printed
+
+
+def test_compile_no_extra_warning_when_no_errors(monkeypatch, test_config):
+    """When no errors occur, print_success is called and no warnings/exit."""
+    source = _raw_source(slug="raw-a", source_url=None)
+    warnings_printed = []
+    success_printed = []
+    exit_raised = False
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "read_manifest", lambda vault_path: Manifest())
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+
+    def capture_warning(message: str):
+        warnings_printed.append(message)
+
+    def capture_success(title: str, message: str):
+        success_printed.append((title, message))
+
+    monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
+    monkeypatch.setattr(compile_cmd, "print_success", capture_success)
+
+    async def fake_run(sources, manifest, config, provider, dry_run):
+        return (
+            compile_cmd.CompileResult(
+                articles_created=1,
+                articles_updated=0,
+                sources_compiled=len(sources),
+                errors=[],
+            ),
+            {"concept-a": [source.relative_path]},
+        )
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", fake_run)
+    monkeypatch.setattr(compile_cmd, "_rebuild_wiki_index", lambda config, manifest, provider: None)
+
+    def mock_exit(code: int):
+        nonlocal exit_raised
+        exit_raised = True
+        raise StopIteration(code)
+
+    monkeypatch.setattr(typer, "Exit", mock_exit)
+
+    compile_cmd.compile(full=False, dry_run=False, verbose=False)
+
+    assert exit_raised is False
+    assert len(warnings_printed) == 0
+    assert len(success_printed) == 1
+    assert success_printed[0][0] == "Compile complete"
+
+
+def test_compile_prints_success_on_clean_noop(monkeypatch, test_config):
+    """When compile processes zero sources (no creations, updates, or errors), still print success."""
+    source = _raw_source(slug="raw-a", source_url=None)
+    warnings_printed = []
+    success_printed = []
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "read_manifest", lambda vault_path: Manifest())
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+
+    def capture_warning(message: str):
+        warnings_printed.append(message)
+
+    def capture_success(title: str, message: str):
+        success_printed.append((title, message))
+
+    monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
+    monkeypatch.setattr(compile_cmd, "print_success", capture_success)
+
+    async def fake_run(sources, manifest, config, provider, dry_run):
+        return (
+            compile_cmd.CompileResult(
+                articles_created=0,
+                articles_updated=0,
+                sources_compiled=len(sources),
+                errors=[],
+            ),
+            {},
+        )
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", fake_run)
+    monkeypatch.setattr(compile_cmd, "_rebuild_wiki_index", lambda config, manifest, provider: None)
+
+    def mock_exit(code: int):
+        raise StopIteration(code)
+
+    monkeypatch.setattr(typer, "Exit", mock_exit)
+
+    compile_cmd.compile(full=False, dry_run=False, verbose=False)
+
+    assert len(warnings_printed) == 0
+    assert len(success_printed) == 1
+    assert success_printed[0][0] == "Compile complete"

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from vaultmind.ai.compiler import _deduplicate_concepts, compile_sources
+from vaultmind.commands.compile import _run_compile_async
 from vaultmind.core.raw_scanner import RawSourceRecord
 from vaultmind.schemas import ConceptStatus, Manifest, WikiConceptEntry
 
@@ -109,3 +110,186 @@ def test_deduplicate_concepts_preserves_existing_status_when_response_omits_stat
     assert len(deduped) == 1
     assert deduped[0].status == ConceptStatus.EXISTING
     assert deduped[0].merge_target == "attention"
+
+
+def test_compile_sources_continues_when_one_concept_create_fails_and_names_it_in_errors(
+    test_config, tmp_path
+):
+    """When one concept's article create fails, other concepts still succeed and error is named."""
+    success_source = _raw_source(slug="success-source", source_url="https://example.com/success")
+    failing_source = _raw_source(slug="fail-source", source_url="https://example.com/fail")
+
+    # Setup wiki concepts directory for article writes
+    article_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    article_dir.mkdir(parents=True, exist_ok=True)
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Success Concept",
+                    "status": "new",
+                    "description": "This one will succeed",
+                    "source_urls": [success_source.source_url],
+                },
+                {
+                    "name": "Failing Concept",
+                    "status": "new",
+                    "description": "This one will fail",
+                    "source_urls": [failing_source.source_url],
+                },
+            ]
+        }
+    )
+
+    # Dedup response — keep the two concepts as-is
+    dedup = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Success Concept",
+                    "status": "new",
+                    "description": "This one will succeed",
+                    "source_urls": [success_source.source_url],
+                },
+                {
+                    "name": "Failing Concept",
+                    "status": "new",
+                    "description": "This one will fail",
+                    "source_urls": [failing_source.source_url],
+                },
+            ]
+        }
+    )
+
+    class FailingProvider(StubProvider):
+        """Provider that fails on specific concept names."""
+
+        def __init__(self):
+            # Responses for triage, dedup, and one article creation (second will fail)
+            super().__init__([
+                triage,
+                dedup,
+                "# Success Concept\n\nSuccess content",
+            ])
+
+        async def complete(self, prompt: str, system: str = "") -> str:
+            del system
+            self.prompts.append(prompt)
+            # Fail only on article creation prompts for "Failing Concept"
+            # Article creation prompts contain "Write a new wiki article for the concept"
+            if "Write a new wiki article" in prompt and "Failing Concept" in prompt:
+                raise ValueError("Simulated article creation failure")
+            response = self.responses.pop(0)
+            return response
+
+    provider = FailingProvider()
+
+    result, slug_to_urls = asyncio.run(
+        compile_sources(
+            [success_source, failing_source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    # Success concept should have been created
+    assert result.articles_created == 1
+    # One error should be recorded with the concept name
+    assert len(result.errors) == 1
+    assert "Concept 'Failing Concept' failed:" in result.errors[0]
+    # Success concept should be in slug_to_urls
+    assert "success-concept" in slug_to_urls
+    # Article file should exist for success concept
+    success_article = article_dir / "success-concept.md"
+    assert success_article.exists()
+
+
+def test_compile_run_skips_manifest_update_for_failed_source(test_config):
+    """When one concept fails, only successful sources update the manifest."""
+    success_source = _raw_source(slug="success-source", source_url="https://example.com/success")
+    failing_source = _raw_source(slug="fail-source", source_url="https://example.com/fail")
+
+    # Setup wiki concepts directory for article writes
+    article_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    article_dir.mkdir(parents=True, exist_ok=True)
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Success Concept",
+                    "status": "new",
+                    "description": "This one will succeed",
+                    "source_urls": [success_source.source_url],
+                },
+                {
+                    "name": "Failing Concept",
+                    "status": "new",
+                    "description": "This one will fail",
+                    "source_urls": [failing_source.source_url],
+                },
+            ]
+        }
+    )
+
+    # Dedup response — keep the two concepts as-is
+    dedup = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Success Concept",
+                    "status": "new",
+                    "description": "This one will succeed",
+                    "source_urls": [success_source.source_url],
+                },
+                {
+                    "name": "Failing Concept",
+                    "status": "new",
+                    "description": "This one will fail",
+                    "source_urls": [failing_source.source_url],
+                },
+            ]
+        }
+    )
+
+    class FailingProvider(StubProvider):
+        """Provider that fails on specific concept names."""
+
+        def __init__(self):
+            # Responses for triage, dedup, and one article creation (second will fail)
+            super().__init__([
+                triage,
+                dedup,
+                "# Success Concept\n\nSuccess content",
+            ])
+
+        async def complete(self, prompt: str, system: str = "") -> str:
+            del system
+            self.prompts.append(prompt)
+            # Fail only on article creation prompts for "Failing Concept"
+            if "Write a new wiki article" in prompt and "Failing Concept" in prompt:
+                raise ValueError("Simulated article creation failure")
+            response = self.responses.pop(0)
+            return response
+
+    provider = FailingProvider()
+    manifest = Manifest()
+
+    # Call _run_compile_async directly to test manifest update behavior
+    _result, _slug_to_urls = asyncio.run(
+        _run_compile_async(
+            [success_source, failing_source],
+            manifest,
+            test_config,
+            provider,
+            dry_run=False,
+        )
+    )
+
+    # Verify the manifest was updated only for the successful source
+    assert success_source.source_url in manifest.sources
+    assert failing_source.source_url not in manifest.sources
+    assert "success-concept" in manifest.wiki_articles


### PR DESCRIPTION
Closes #8.

`vm compile` previously collected per-concept errors but never showed them and always exited 0. Now:

- Per-concept failures are formatted `Concept '<name>' failed: <reason>` and one failing concept no longer cancels its siblings.
- Each error is printed via `print_warning`, then `typer.Exit(1)`.
- The success panel stays on the clean no-op (0 created / 0 updated / 0 errors); it's only suppressed when nothing succeeded *and* something failed.
- New tests pin: per-concept error naming, manifest only tracks successes, exit code is 1, and the no-op happy path still prints.

135 passed, ruff and mypy clean.