### PR TITLE
Preserve compile source provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,12 @@ created: 2026-05-16T00:00:00+00:00
 
 ## CLI
 
-Core commands:
+Core commands available today:
 
 ```bash
 vm init
 vm compile
 vm ask
-vm lint
 ```
 
 Supporting commands:
@@ -278,6 +277,12 @@ Secondary helper commands:
 ```bash
 vm save <url>
 vm flashcard
+```
+
+Planned health command:
+
+```bash
+vm lint
 ```
 
 ## Installation
@@ -333,4 +338,3 @@ VaultMind is working when:
 - the index and log make the system navigable,
 - lint catches wiki decay before the user loses trust,
 - the vault feels smarter, not merely larger.
-

--- a/src/vaultmind/ai/compiler.py
+++ b/src/vaultmind/ai/compiler.py
@@ -51,7 +51,7 @@ class CompileResult:
 
 def _extract_h1_title(body: str) -> str | None:
     """Extract title from the first H1 heading in a markdown body."""
-    match = re.match(r"^#\s+(.+?)\s*$", body.strip(), re.MULTILINE)
+    match = re.search(r"^#\s+(.+?)\s*$", body.strip(), re.MULTILINE)
     return match.group(1).strip() if match else None
 
 
@@ -61,6 +61,62 @@ def _strip_h1(body: str) -> str:
     if lines and re.match(r"^#\s+", lines[0]):
         return "\n".join(lines[1:]).lstrip("\n")
     return body
+
+
+def _extract_frontmatter(markdown: str) -> dict[str, object]:
+    """Extract a markdown frontmatter block as a mapping."""
+    if not markdown.startswith("---"):
+        return {}
+
+    end = markdown.find("---", 3)
+    if end == -1:
+        return {}
+
+    try:
+        import yaml
+
+        data = yaml.safe_load(markdown[3:end])
+    except yaml.YAMLError:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _extract_frontmatter_title(markdown: str) -> str | None:
+    """Extract a title from wiki article frontmatter."""
+    title = _extract_frontmatter(markdown).get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return None
+
+
+def _extract_frontmatter_sources(markdown: str) -> list[str]:
+    """Extract source URLs/keys from a wiki article frontmatter block."""
+    data = _extract_frontmatter(markdown)
+    if not data:
+        return []
+
+    sources = data.get("sources")
+    if isinstance(sources, list):
+        return [str(source) for source in sources if source]
+    if isinstance(sources, str):
+        return [sources]
+    return []
+
+
+def _merge_source_urls(*source_groups: list[str]) -> list[str]:
+    """Merge source URL/key lists while preserving first-seen order."""
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in source_groups:
+        for source in group:
+            if source in seen:
+                continue
+            seen.add(source)
+            merged.append(source)
+    return merged
 
 
 def slugify(text: str) -> str:
@@ -276,8 +332,16 @@ async def _update_and_write_article(
 ) -> None:
     """Update a wiki article via LLM and write it to disk."""
     body = await _update_article(existing_content, concept, url_to_source, provider)
-    title = _extract_h1_title(existing_content) or slug.replace("-", " ").title()
-    _write_wiki_article(slug, body, title, concept.source_urls, vault_path, folders)
+    title = (
+        _extract_frontmatter_title(existing_content)
+        or _extract_h1_title(existing_content)
+        or slug.replace("-", " ").title()
+    )
+    source_urls = _merge_source_urls(
+        _extract_frontmatter_sources(existing_content),
+        concept.source_urls,
+    )
+    _write_wiki_article(slug, body, title, source_urls, vault_path, folders)
 
 
 def _write_wiki_article(

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 from vaultmind.ai.compiler import _deduplicate_concepts, compile_sources
 from vaultmind.commands.compile import _run_compile_async
-from vaultmind.core.raw_scanner import RawSourceRecord
+from vaultmind.core.manifest import read_manifest
+from vaultmind.core.raw_scanner import RawSourceRecord, scan_raw_sources
 from vaultmind.schemas import ConceptStatus, Manifest, WikiConceptEntry
 
 
@@ -71,6 +72,117 @@ def test_compile_sources_updates_existing_article_with_relative_path_raw_body(te
     assert result.articles_created == 0
     assert slug_to_urls == {"concept-a": [source.relative_path]}
     assert "Body text from raw-a" in provider.prompts[1]
+
+
+def test_compile_sources_preserves_existing_frontmatter_sources_on_update(test_config):
+    source = _raw_source(slug="raw-b", source_url="https://example.com/new-source")
+    old_source_url = "https://example.com/old-source"
+    article_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    article_dir.mkdir(parents=True, exist_ok=True)
+    article_path = article_dir / "concept-a.md"
+    article_path.write_text(
+        "\n".join(
+            [
+                "---",
+                "title: Human Concept A",
+                "vaultmind: true",
+                "kind: concept",
+                "sources:",
+                f"  - {old_source_url}",
+                "---",
+                "",
+                "# Concept A",
+                "",
+                "Old content",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Concept A",
+                    "status": "existing:concept-a",
+                    "description": "Existing concept with new source",
+                    "source_urls": [source.source_url],
+                    "merge_target": "concept-a",
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# Concept A\n\nUpdated content"])
+
+    result, slug_to_urls = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    updated = article_path.read_text(encoding="utf-8")
+    assert result.articles_updated == 1
+    assert slug_to_urls == {"concept-a": [source.source_url]}
+    assert "title: Human Concept A" in updated
+    assert f"  - {old_source_url}" in updated
+    assert f"  - {source.source_url}" in updated
+
+
+def test_fixture_vault_compile_updates_existing_concept_and_preserves_sources(fixture_vault):
+    records = scan_raw_sources(fixture_vault)
+    source = next(
+        record
+        for record in records
+        if record.source_url == "https://blog.research.google/2023/03/encouraging-sparse-attention-in.html"
+    )
+    old_source_url = "https://lena-voita.github.io/posts/annotated_transformers/attention.html"
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Attention Mechanisms",
+                    "status": "existing:attention-mechanisms",
+                    "description": "Existing attention concept expanded with sparse attention trade-offs",
+                    "source_urls": [source.source_url],
+                    "merge_target": "attention-mechanisms",
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# Attention Mechanisms\n\nUpdated with sparse attention."])
+    manifest = read_manifest(fixture_vault.vault_path)
+
+    result, slug_to_urls = asyncio.run(
+        _run_compile_async(
+            [source],
+            manifest,
+            fixture_vault,
+            provider,
+            dry_run=False,
+        )
+    )
+
+    article_path = (
+        fixture_vault.vault_path
+        / fixture_vault.folders.wiki
+        / fixture_vault.folders.wiki_concepts
+        / "attention-mechanisms.md"
+    )
+    updated = article_path.read_text(encoding="utf-8")
+
+    assert result.articles_updated == 1
+    assert slug_to_urls == {"attention-mechanisms": [source.source_url]}
+    assert source.source_url in manifest.sources
+    assert manifest.sources[source.source_url].wiki_articles == ["attention-mechanisms"]
+    assert old_source_url in manifest.wiki_articles["attention-mechanisms"].source_urls
+    assert source.source_url in manifest.wiki_articles["attention-mechanisms"].source_urls
+    assert f"  - {old_source_url}" in updated
+    assert f"  - {source.source_url}" in updated
 
 
 def test_deduplicate_concepts_preserves_existing_status_when_response_omits_status():


### PR DESCRIPTION
## Summary

This PR hardens the Raw-to-Wiki compile loop around concept updates and documentation honesty.

- Preserves existing concept page `sources` frontmatter when an existing concept is updated.
- Appends new source URLs/keys without dropping previously compiled provenance.
- Preserves human/frontmatter titles when rewriting updated concept pages.
- Moves `vm lint` in the README from available core commands to planned health command, matching the current CLI.
- Adds regression coverage for both direct compiler behavior and a realistic fixture-vault compile update.

## Why

VaultMind is built around durable, accumulating wiki pages. Updating an existing concept should make the wiki smarter, not lose source history from earlier compiles. The manifest was already intended to preserve mappings, but the markdown article frontmatter could be rewritten with only the current compile batch sources. That creates a trust problem for larger vaults.

This PR keeps the concept page itself aligned with the product thesis: sources accumulate over time, and updates remain inspectable in markdown.

## Implementation Notes

- Added frontmatter parsing helpers in `vaultmind.ai.compiler` for existing wiki article title and source extraction.
- Merged old and new source lists in first-seen order for concept updates.
- Switched H1 extraction from `re.match` to `re.search` so H1s after frontmatter are handled correctly.
- Added fixture-vault coverage that updates `attention-mechanisms.md` with the sparse-attention source and verifies both article frontmatter and manifest state.

## Verification

```text
uv run ruff check
uv run mypy src/vaultmind
uv run pytest
```

Result:

```text
ruff: passed
mypy: passed, no issues in 50 source files
pytest: 147 passed
```

## Follow-up

Next recommended slice: issue #7, manifest accuracy. This PR protects markdown page provenance; the next PR should make the manifest state model boring and correct across multi-concept mappings, changed-source detection, skipped sources, and partial failures.