### PR TITLE
Make ask fall back to Raw when wiki context is weak

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,12 @@ created: 2026-05-16T00:00:00+00:00
 
 ## CLI
 
-Core commands:
+Core commands available today:
 
 ```bash
 vm init
 vm compile
 vm ask
-vm lint
 ```
 
 Supporting commands:
@@ -278,6 +277,12 @@ Secondary helper commands:
 ```bash
 vm save <url>
 vm flashcard
+```
+
+Planned health command:
+
+```bash
+vm lint
 ```
 
 ## Installation
@@ -333,4 +338,3 @@ VaultMind is working when:
 - the index and log make the system navigable,
 - lint catches wiki decay before the user loses trust,
 - the vault feels smarter, not merely larger.
-

--- a/src/vaultmind/ai/asker.py
+++ b/src/vaultmind/ai/asker.py
@@ -18,7 +18,7 @@ from vaultmind.ai.prompts import (
 )
 from vaultmind.ai.providers.base import Provider
 from vaultmind.core.raw_scanner import RawSourceRecord, format_raw_source_packet
-from vaultmind.core.search import search_notes
+from vaultmind.core.search import SearchMatch, search_notes
 from vaultmind.core.vault_index import VaultNoteRecord, format_note_packet
 from vaultmind.core.writer import slugify, write_markdown_page
 
@@ -27,6 +27,7 @@ log = structlog.get_logger()
 MAX_ITERATIONS = 3
 MAX_CONTEXT_NOTES = 30
 MAX_CONTEXT_SOURCES = 20
+MIN_WIKI_CONTEXT_SCORE = 35.0
 
 
 @dataclass
@@ -124,8 +125,25 @@ def _initial_search(
     folders_raw: str,
 ) -> GatheredContext:
     """Perform initial search across wiki concepts and raw sources."""
-    wiki_notes: list[VaultNoteRecord] = []
+    wiki_notes = _load_wiki_concepts(vault_path, folders_wiki, folders_wiki_concepts)
+    wiki_matches = search_notes(wiki_notes, question, limit=MAX_CONTEXT_NOTES) if wiki_notes else []
+    matched_wiki_notes = [match.note for match in wiki_matches]
 
+    raw_sources = (
+        []
+        if _wiki_context_is_sufficient(wiki_matches)
+        else _search_raw_sources(question, vault_path, folders_raw)
+    )
+    return GatheredContext(wiki_notes=matched_wiki_notes, raw_sources=raw_sources)
+
+
+def _load_wiki_concepts(
+    vault_path: Path,
+    folders_wiki: str,
+    folders_wiki_concepts: str,
+) -> list[VaultNoteRecord]:
+    """Load wiki concept pages as note records for ask-time search."""
+    wiki_notes: list[VaultNoteRecord] = []
     wiki_concepts_dir = vault_path / folders_wiki / folders_wiki_concepts
     if wiki_concepts_dir.exists():
         for md_file in wiki_concepts_dir.glob("*.md"):
@@ -155,14 +173,12 @@ def _initial_search(
                 raw_frontmatter=frontmatter,
             ))
 
-    if wiki_notes:
-        matches = search_notes(wiki_notes, question, limit=MAX_CONTEXT_NOTES)
-        scored = {m.note.relative_path: m.score for m in matches}
-        wiki_notes.sort(key=lambda n: scored.get(n.relative_path, 0), reverse=True)
-        wiki_notes = wiki_notes[:MAX_CONTEXT_NOTES]
+    return wiki_notes
 
-    raw_sources = [] if wiki_notes else _search_raw_sources(question, vault_path, folders_raw)
-    return GatheredContext(wiki_notes=wiki_notes, raw_sources=raw_sources)
+
+def _wiki_context_is_sufficient(matches: list[SearchMatch]) -> bool:
+    """Return True when wiki matches are strong enough to skip Raw fallback."""
+    return bool(matches) and matches[0].score >= MIN_WIKI_CONTEXT_SCORE
 
 
 def _follow_up_gap(

--- a/src/vaultmind/ai/compiler.py
+++ b/src/vaultmind/ai/compiler.py
@@ -51,7 +51,7 @@ class CompileResult:
 
 def _extract_h1_title(body: str) -> str | None:
     """Extract title from the first H1 heading in a markdown body."""
-    match = re.match(r"^#\s+(.+?)\s*$", body.strip(), re.MULTILINE)
+    match = re.search(r"^#\s+(.+?)\s*$", body.strip(), re.MULTILINE)
     return match.group(1).strip() if match else None
 
 
@@ -61,6 +61,62 @@ def _strip_h1(body: str) -> str:
     if lines and re.match(r"^#\s+", lines[0]):
         return "\n".join(lines[1:]).lstrip("\n")
     return body
+
+
+def _extract_frontmatter(markdown: str) -> dict[str, object]:
+    """Extract a markdown frontmatter block as a mapping."""
+    if not markdown.startswith("---"):
+        return {}
+
+    end = markdown.find("---", 3)
+    if end == -1:
+        return {}
+
+    try:
+        import yaml
+
+        data = yaml.safe_load(markdown[3:end])
+    except yaml.YAMLError:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _extract_frontmatter_title(markdown: str) -> str | None:
+    """Extract a title from wiki article frontmatter."""
+    title = _extract_frontmatter(markdown).get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return None
+
+
+def _extract_frontmatter_sources(markdown: str) -> list[str]:
+    """Extract source URLs/keys from a wiki article frontmatter block."""
+    data = _extract_frontmatter(markdown)
+    if not data:
+        return []
+
+    sources = data.get("sources")
+    if isinstance(sources, list):
+        return [str(source) for source in sources if source]
+    if isinstance(sources, str):
+        return [sources]
+    return []
+
+
+def _merge_source_urls(*source_groups: list[str]) -> list[str]:
+    """Merge source URL/key lists while preserving first-seen order."""
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in source_groups:
+        for source in group:
+            if source in seen:
+                continue
+            seen.add(source)
+            merged.append(source)
+    return merged
 
 
 def slugify(text: str) -> str:
@@ -276,8 +332,16 @@ async def _update_and_write_article(
 ) -> None:
     """Update a wiki article via LLM and write it to disk."""
     body = await _update_article(existing_content, concept, url_to_source, provider)
-    title = _extract_h1_title(existing_content) or slug.replace("-", " ").title()
-    _write_wiki_article(slug, body, title, concept.source_urls, vault_path, folders)
+    title = (
+        _extract_frontmatter_title(existing_content)
+        or _extract_h1_title(existing_content)
+        or slug.replace("-", " ").title()
+    )
+    source_urls = _merge_source_urls(
+        _extract_frontmatter_sources(existing_content),
+        concept.source_urls,
+    )
+    _write_wiki_article(slug, body, title, source_urls, vault_path, folders)
 
 
 def _write_wiki_article(

--- a/tests/test_asker.py
+++ b/tests/test_asker.py
@@ -13,6 +13,7 @@ from vaultmind.ai.asker import (
     _extract_answer_text,
     _extract_gaps_from_assessment,
     _follow_up_gap,
+    _initial_search,
     _render_answer_markdown,
     _slug_from_question,
     ask_question,
@@ -199,6 +200,51 @@ class TestFollowUpGap:
         # Gap found a note with same title "Attention" — deduplication prevents adding a second
         titles = [n.title for n in ctx.wiki_notes]
         assert titles.count("Attention") == 1
+
+
+class TestInitialSearch:
+    def test_falls_back_to_raw_when_wiki_has_no_matches(self, tmp_path: Path):
+        vault = tmp_path / "vault"
+        wiki_dir = vault / "🗺️ Wiki" / "🧠 Concepts"
+        raw_dir = vault / "📥 Raw"
+        wiki_dir.mkdir(parents=True)
+        raw_dir.mkdir(parents=True)
+
+        (wiki_dir / "attention.md").write_text(
+            "---\ntitle: Attention\nvaultmind: true\nkind: concept\n---\n\n# Attention\n\nTransformer attention notes.",
+            encoding="utf-8",
+        )
+        (raw_dir / "rlhf.md").write_text(
+            "---\nsource: https://example.com/rlhf\n---\n\n# RLHF\n\nRLHF uses human feedback.",
+            encoding="utf-8",
+        )
+
+        ctx = _initial_search("What is RLHF?", vault, "🗺️ Wiki", "🧠 Concepts", "📥 Raw")
+
+        assert ctx.wiki_notes == []
+        assert len(ctx.raw_sources) == 1
+        assert ctx.raw_sources[0].title == "RLHF"
+
+    def test_skips_raw_when_wiki_match_is_strong(self, tmp_path: Path):
+        vault = tmp_path / "vault"
+        wiki_dir = vault / "🗺️ Wiki" / "🧠 Concepts"
+        raw_dir = vault / "📥 Raw"
+        wiki_dir.mkdir(parents=True)
+        raw_dir.mkdir(parents=True)
+
+        (wiki_dir / "rlhf.md").write_text(
+            "---\ntitle: RLHF\nvaultmind: true\nkind: concept\n---\n\n# RLHF\n\nRLHF notes.",
+            encoding="utf-8",
+        )
+        (raw_dir / "rlhf-source.md").write_text(
+            "# RLHF source\n\nRLHF uses human feedback.",
+            encoding="utf-8",
+        )
+
+        ctx = _initial_search("RLHF", vault, "🗺️ Wiki", "🧠 Concepts", "📥 Raw")
+
+        assert [note.title for note in ctx.wiki_notes] == ["RLHF"]
+        assert ctx.raw_sources == []
 
 
 class TestAskResult:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 from vaultmind.ai.compiler import _deduplicate_concepts, compile_sources
 from vaultmind.commands.compile import _run_compile_async
-from vaultmind.core.raw_scanner import RawSourceRecord
+from vaultmind.core.manifest import read_manifest
+from vaultmind.core.raw_scanner import RawSourceRecord, scan_raw_sources
 from vaultmind.schemas import ConceptStatus, Manifest, WikiConceptEntry
 
 
@@ -71,6 +72,117 @@ def test_compile_sources_updates_existing_article_with_relative_path_raw_body(te
     assert result.articles_created == 0
     assert slug_to_urls == {"concept-a": [source.relative_path]}
     assert "Body text from raw-a" in provider.prompts[1]
+
+
+def test_compile_sources_preserves_existing_frontmatter_sources_on_update(test_config):
+    source = _raw_source(slug="raw-b", source_url="https://example.com/new-source")
+    old_source_url = "https://example.com/old-source"
+    article_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    article_dir.mkdir(parents=True, exist_ok=True)
+    article_path = article_dir / "concept-a.md"
+    article_path.write_text(
+        "\n".join(
+            [
+                "---",
+                "title: Human Concept A",
+                "vaultmind: true",
+                "kind: concept",
+                "sources:",
+                f"  - {old_source_url}",
+                "---",
+                "",
+                "# Concept A",
+                "",
+                "Old content",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Concept A",
+                    "status": "existing:concept-a",
+                    "description": "Existing concept with new source",
+                    "source_urls": [source.source_url],
+                    "merge_target": "concept-a",
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# Concept A\n\nUpdated content"])
+
+    result, slug_to_urls = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    updated = article_path.read_text(encoding="utf-8")
+    assert result.articles_updated == 1
+    assert slug_to_urls == {"concept-a": [source.source_url]}
+    assert "title: Human Concept A" in updated
+    assert f"  - {old_source_url}" in updated
+    assert f"  - {source.source_url}" in updated
+
+
+def test_fixture_vault_compile_updates_existing_concept_and_preserves_sources(fixture_vault):
+    records = scan_raw_sources(fixture_vault)
+    source = next(
+        record
+        for record in records
+        if record.source_url == "https://blog.research.google/2023/03/encouraging-sparse-attention-in.html"
+    )
+    old_source_url = "https://lena-voita.github.io/posts/annotated_transformers/attention.html"
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Attention Mechanisms",
+                    "status": "existing:attention-mechanisms",
+                    "description": "Existing attention concept expanded with sparse attention trade-offs",
+                    "source_urls": [source.source_url],
+                    "merge_target": "attention-mechanisms",
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# Attention Mechanisms\n\nUpdated with sparse attention."])
+    manifest = read_manifest(fixture_vault.vault_path)
+
+    result, slug_to_urls = asyncio.run(
+        _run_compile_async(
+            [source],
+            manifest,
+            fixture_vault,
+            provider,
+            dry_run=False,
+        )
+    )
+
+    article_path = (
+        fixture_vault.vault_path
+        / fixture_vault.folders.wiki
+        / fixture_vault.folders.wiki_concepts
+        / "attention-mechanisms.md"
+    )
+    updated = article_path.read_text(encoding="utf-8")
+
+    assert result.articles_updated == 1
+    assert slug_to_urls == {"attention-mechanisms": [source.source_url]}
+    assert source.source_url in manifest.sources
+    assert manifest.sources[source.source_url].wiki_articles == ["attention-mechanisms"]
+    assert old_source_url in manifest.wiki_articles["attention-mechanisms"].source_urls
+    assert source.source_url in manifest.wiki_articles["attention-mechanisms"].source_urls
+    assert f"  - {old_source_url}" in updated
+    assert f"  - {source.source_url}" in updated
 
 
 def test_deduplicate_concepts_preserves_existing_status_when_response_omits_status():


### PR DESCRIPTION
## Summary
- filters ask-time wiki context to actual search matches instead of every concept page
- falls back to Raw when wiki matches are missing or weak
- keeps strong wiki matches wiki-first and avoids unnecessary Raw context

## Stack note
This branch includes the compile provenance fix from #12. Review/merge #12 first; after #12 lands, this PR should effectively reduce to the ask context-selection change.

## Verification
- uv run ruff check
- uv run mypy src/vaultmind
- uv run pytest