### PR TITLE
Preserve manifest provenance from concept frontmatter

### DIFF
--- a/src/vaultmind/commands/compile.py
+++ b/src/vaultmind/commands/compile.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import structlog
 import typer
+import yaml
 
 from vaultmind.ai.compiler import CompileResult, compile_sources, rebuild_index
 from vaultmind.ai.providers import Provider, get_provider
@@ -170,11 +171,16 @@ async def _run_compile_async(
                 slug = article_path.stem
                 body = article_path.read_text(encoding="utf-8")
                 article_hash = content_hash(body)
-                # Find source URLs that fed this article
-                source_urls = [
+                # Find source URLs that fed this article, preserving any
+                # existing frontmatter provenance on the concept page.
+                manifest_source_urls = [
                     url for url, entry in manifest.sources.items()
                     if slug in entry.wiki_articles
                 ]
+                source_urls = _merge_source_urls(
+                    _extract_article_sources(article_path),
+                    manifest_source_urls,
+                )
                 upsert_wiki_article(
                     manifest,
                     slug=slug,
@@ -195,6 +201,56 @@ async def _run_compile_async(
         )
 
     return result, slug_to_urls
+
+
+def _extract_article_sources(article_path: Path) -> list[str]:
+    """Extract source URLs/keys from concept article frontmatter."""
+    try:
+        text = article_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+
+    if not text.startswith("---"):
+        return []
+
+    end = text.find("---", 3)
+    if end == -1:
+        return []
+
+    try:
+        data = yaml.safe_load(text[3:end])
+    except yaml.YAMLError:
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    sources = data.get("sources")
+    if isinstance(sources, list):
+        parsed_sources: list[str] = []
+        for source in sources:
+            if source is None:
+                continue
+            source_text = str(source).strip()
+            if source_text:
+                parsed_sources.append(source_text)
+        return parsed_sources
+    if isinstance(sources, str) and sources.strip():
+        return [sources.strip()]
+    return []
+
+
+def _merge_source_urls(*source_groups: list[str]) -> list[str]:
+    """Merge source URL/key lists while preserving first-seen order."""
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in source_groups:
+        for source in group:
+            if source in seen:
+                continue
+            seen.add(source)
+            merged.append(source)
+    return merged
 
 
 def _extract_article_title(article_path: Path) -> str:

--- a/tests/test_commands/test_compile.py
+++ b/tests/test_commands/test_compile.py
@@ -216,6 +216,74 @@ def test_run_compile_async_writes_manifest_and_compile_log(monkeypatch, test_con
     assert "compile | 1 created, 0 updated, 1 source(s)" in log_text
 
 
+def test_run_compile_async_preserves_article_frontmatter_sources_in_manifest(
+    monkeypatch,
+    test_config,
+):
+    old_source_url = "https://example.com/old-source"
+    new_source = _raw_source(slug="raw-b", source_url="https://example.com/new-source")
+    concepts_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    concepts_dir.mkdir(parents=True, exist_ok=True)
+    (concepts_dir / "concept-a.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "title: Concept A",
+                "vaultmind: true",
+                "kind: concept",
+                "sources:",
+                f"  - {old_source_url}",
+                "---",
+                "",
+                "# Concept A",
+                "",
+                "Updated content",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    manifest = Manifest()
+
+    async def fake_compile_sources(
+        sources,
+        manifest_arg,
+        provider,
+        vault_path,
+        folders,
+        *,
+        dry_run=False,
+        existing_concepts=None,
+    ):
+        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts
+        return (
+            compile_cmd.CompileResult(
+                articles_created=0,
+                articles_updated=1,
+                sources_compiled=len(sources),
+                errors=[],
+            ),
+            {"concept-a": [new_source.source_url]},
+        )
+
+    monkeypatch.setattr(compile_cmd, "compile_sources", fake_compile_sources)
+
+    asyncio.run(
+        compile_cmd._run_compile_async(
+            [new_source],
+            manifest,
+            test_config,
+            provider=object(),
+            dry_run=False,
+        )
+    )
+
+    assert manifest.sources[new_source.source_url].wiki_articles == ["concept-a"]
+    assert manifest.wiki_articles["concept-a"].source_urls == [
+        old_source_url,
+        new_source.source_url,
+    ]
+
+
 def test_render_dry_run_summary_includes_sources_and_targets():
     from vaultmind.commands import compile as compile_cmd
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -185,6 +185,42 @@ def test_fixture_vault_compile_updates_existing_concept_and_preserves_sources(fi
     assert f"  - {source.source_url}" in updated
 
 
+def test_compile_sources_dry_run_does_not_write_concept_pages(test_config):
+    source = _raw_source(slug="dry-run-source", source_url="https://example.com/dry-run")
+    article_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    article_path = article_dir / "dry-run-concept.md"
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Dry Run Concept",
+                    "status": "new",
+                    "description": "A concept that should not be written",
+                    "source_urls": [source.source_url],
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage])
+
+    result, slug_to_urls = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            dry_run=True,
+        )
+    )
+
+    assert result.articles_created == 0
+    assert result.articles_updated == 0
+    assert slug_to_urls == {"dry-run-concept": [source.source_url]}
+    assert provider.responses == []
+    assert not article_path.exists()
+
+
 def test_deduplicate_concepts_preserves_existing_status_when_response_omits_status():
     concepts = [
         WikiConceptEntry(


### PR DESCRIPTION
## Summary
- merge concept-page frontmatter sources into manifest wiki article source sets
- keep preserved page provenance visible in vault.manifest.json even when source entries are stale or incomplete
- add a real compile_sources dry-run regression test that verifies concept pages are not written

## Review follow-up
Addresses the review finding that concept page provenance could be preserved in markdown while drifting out of manifest.wiki_articles source_urls.

## Verification
- uv run ruff check
- uv run mypy src/vaultmind
- uv run pytest