### PR TITLE
Harden compilation and complete the compounding ask loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ It should:
 2. Detect new or changed source files.
 3. Read the current wiki index and known concept pages.
 4. Ask the LLM which concepts should be created or updated.
-5. Create or update pages in `🗺️ Wiki/🧠 Concepts/`.
+5. Create or update pages in `🗺️ Wiki/🧠 Concepts/` from bounded packets of the attributed Raw source text.
 6. Update `🗺️ Wiki/📇 Index.md`.
 7. Append to `🗺️ Wiki/📋 Log.md`.
 8. Update `vault.manifest.json`.
 
-Compile should be conservative. Updating an existing concept page is usually better than creating a duplicate page.
+Compile should be conservative. Updating an existing concept page is usually better than creating a duplicate page. Article generation and updates are grounded in bounded Raw source packets, and VaultMind deterministically enforces the concept-page headings and synchronizes source citations before each atomic write.
 
 ### Ask
 
@@ -188,7 +188,7 @@ Concept pages live in:
 🗺️ Wiki/🧠 Concepts/{slug}.md
 ```
 
-Recommended shape:
+Required shape:
 
 ```markdown
 ---
@@ -254,11 +254,21 @@ vm version     # print the version
 No-write/preview modes keep every command safe to dry-run:
 
 ```bash
-vm compile --dry-run   # show what would compile, write nothing
-vm ask "..." --preview # print the answer without filing it
+vm compile --dry-run          # show what would compile; no writes or propagation calls
+vm compile --max-touches 5    # cap existing pages touched per source (0 disables propagation)
+vm ask "..." --preview        # print the answer without filing it
 vm lint --preview      # print the health report without writing it
 vm lint --strict       # exit non-zero if any error-severity findings
 ```
+
+After creating or updating concepts, `vm compile` may propagate links into existing
+concept pages. Each source can touch at most `--max-touches` pages (default: 5),
+adding a constrained `Connections` wikilink and source provenance. Repeated
+propagation is idempotent against the page currently on disk. If a propagation
+provider call or page write fails, that source's current hash is not recorded;
+the command exits non-zero and the next incremental compile retries the source.
+Touches that were written before a later failure remain recorded in both manifest
+directions. `--dry-run` performs neither propagation calls nor writes.
 
 See `vm <command> --help` for all flags.
 
@@ -301,7 +311,7 @@ The config stores vault paths, folder names, and AI provider preferences. The `.
 1. Make `vm compile` robust: existing concept awareness, multi-concept manifest mappings, index rebuild, log writes.
 2. Make `vm ask` robust: wiki-first search, Raw fallback, true preview mode, filed query metadata.
 3. `vm lint` shipped: deterministic wiki-health report (orphan/uncompiled raw, sourceless pages, broken wikilinks, stale index, duplicate concepts). Next: surface its findings into `compile`/`ask`, and consider opt-in autofix.
-4. Honor the page contracts end-to-end: concept pages should carry Connections + Open Questions; query pages should fill Follow-up Questions from `vm ask`'s self-assessed gaps (currently computed but discarded).
+4. Complete the remaining query-page contract: concept-page structure and citations are now enforced during compilation; query pages should fill Follow-up Questions from `vm ask`'s self-assessed gaps (currently computed but discarded).
 
 ## Success Criteria
 

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Ask is the second compounding loop.
 vm ask "What is the difference between RLHF and DPO?"
 ```
 
-It should:
+It:
 
-1. Search the compiled wiki first.
-2. Search Raw only when the wiki is insufficient.
-3. Produce a grounded answer.
-4. In normal mode, file the answer to `🗺️ Wiki/📊 Queries/`.
-5. In preview mode, print without writing.
+1. Searches compiled concept pages and previously filed query answers first.
+2. Searches Raw only when the combined wiki results are insufficient.
+3. In deep mode, performs up to three grounded synthesis passes, searching each self-assessed gap between passes and stopping early when no gaps remain.
+4. Files the answer and its final follow-up gaps to `🗺️ Wiki/📊 Queries/` in normal mode, making the answer searchable context for later questions.
+5. Prints without creating files, folders, manifest changes, or log entries in preview mode.
 
 ### Lint
 
@@ -218,7 +218,7 @@ Query pages live in:
 🗺️ Wiki/📊 Queries/{question-slug}.md
 ```
 
-Recommended shape:
+Required shape:
 
 ```markdown
 ---
@@ -308,10 +308,10 @@ The config stores vault paths, folder names, and AI provider preferences. The `.
 
 ## Current Engineering Priorities
 
-1. Make `vm compile` robust: existing concept awareness, multi-concept manifest mappings, index rebuild, log writes.
-2. Make `vm ask` robust: wiki-first search, Raw fallback, true preview mode, filed query metadata.
-3. `vm lint` shipped: deterministic wiki-health report (orphan/uncompiled raw, sourceless pages, broken wikilinks, stale index, duplicate concepts). Next: surface its findings into `compile`/`ask`, and consider opt-in autofix.
-4. Complete the remaining query-page contract: concept-page structure and citations are now enforced during compilation; query pages should fill Follow-up Questions from `vm ask`'s self-assessed gaps (currently computed but discarded).
+1. Strengthen `vm compile` conservatism and recovery for larger, evolving vaults.
+2. Improve Ask retrieval quality without sacrificing wiki-first behavior, bounded context, or preview safety.
+3. Surface deterministic `vm lint` findings in compile and Ask workflows, and evaluate opt-in autofix.
+4. Improve citation verification while preserving readable, contract-compliant concept and query pages.
 
 ## Success Criteria
 

--- a/src/vaultmind/ai/asker.py
+++ b/src/vaultmind/ai/asker.py
@@ -107,7 +107,14 @@ def _extract_gaps_from_assessment(assessment_response: str) -> list[str]:
         data = json.loads(cleaned)
         gaps = data.get("gaps", [])
         if isinstance(gaps, list):
-            return [g for g in gaps if isinstance(g, str) and g.strip()]
+            normalized: list[str] = []
+            for gap in gaps:
+                if not isinstance(gap, str):
+                    continue
+                clean_gap = " ".join(gap.split())
+                if clean_gap and clean_gap not in normalized:
+                    normalized.append(clean_gap)
+            return normalized
         return []
     except (json.JSONDecodeError, TypeError):
         pass
@@ -123,9 +130,18 @@ def _initial_search(
     folders_wiki: str,
     folders_wiki_concepts: str,
     folders_raw: str,
+    folders_wiki_queries: str = "📊 Queries",
+    excluded_wiki_paths: set[str] | None = None,
 ) -> GatheredContext:
-    """Perform initial search across wiki concepts and raw sources."""
-    wiki_notes = _load_wiki_concepts(vault_path, folders_wiki, folders_wiki_concepts)
+    """Search concept and filed-query pages, falling back to Raw when needed."""
+    excluded = excluded_wiki_paths or set()
+    wiki_notes = [
+        note
+        for note in _load_searchable_wiki_notes(
+            vault_path, folders_wiki, folders_wiki_concepts, folders_wiki_queries
+        )
+        if note.relative_path not in excluded
+    ]
     wiki_matches = search_notes(wiki_notes, question, limit=MAX_CONTEXT_NOTES) if wiki_notes else []
     matched_wiki_notes = [match.note for match in wiki_matches]
 
@@ -137,23 +153,28 @@ def _initial_search(
     return GatheredContext(wiki_notes=matched_wiki_notes, raw_sources=raw_sources)
 
 
-def _load_wiki_concepts(
+def _load_searchable_wiki_notes(
     vault_path: Path,
     folders_wiki: str,
     folders_wiki_concepts: str,
+    folders_wiki_queries: str | None,
 ) -> list[VaultNoteRecord]:
-    """Load wiki concept pages as note records for ask-time search."""
+    """Load concept and filed-query pages as ask-time note records."""
     wiki_notes: list[VaultNoteRecord] = []
-    wiki_concepts_dir = vault_path / folders_wiki / folders_wiki_concepts
-    if wiki_concepts_dir.exists():
-        for md_file in wiki_concepts_dir.glob("*.md"):
+    for folder in (folders_wiki_concepts, folders_wiki_queries):
+        if folder is None:
+            continue
+        wiki_dir = vault_path / folders_wiki / folder
+        if not wiki_dir.exists():
+            continue
+        for md_file in wiki_dir.glob("*.md"):
             frontmatter = _read_frontmatter(md_file)
             if not frontmatter:
                 continue
 
             body = _strip_frontmatter(md_file.read_text(encoding="utf-8"))
             title = str(frontmatter.get("title") or md_file.stem.replace("-", " ").title())
-            saved_at = _parse_datetime(frontmatter.get("saved"))
+            saved_at = _parse_datetime(frontmatter.get("saved") or frontmatter.get("created"))
 
             wiki_notes.append(VaultNoteRecord(
                 path=md_file,
@@ -176,6 +197,15 @@ def _load_wiki_concepts(
     return wiki_notes
 
 
+def _load_wiki_concepts(
+    vault_path: Path,
+    folders_wiki: str,
+    folders_wiki_concepts: str,
+) -> list[VaultNoteRecord]:
+    """Load only concept pages (kept for callers that need the old helper)."""
+    return _load_searchable_wiki_notes(vault_path, folders_wiki, folders_wiki_concepts, None)
+
+
 def _wiki_context_is_sufficient(matches: list[SearchMatch]) -> bool:
     """Return True when wiki matches are strong enough to skip Raw fallback."""
     return bool(matches) and matches[0].score >= MIN_WIKI_CONTEXT_SCORE
@@ -188,45 +218,44 @@ def _follow_up_gap(
     folders_wiki: str,
     folders_wiki_concepts: str,
     folders_raw: str,
+    folders_wiki_queries: str = "📊 Queries",
+    excluded_wiki_paths: set[str] | None = None,
 ) -> None:
-    """Search for content related to a gap and add to gathered context."""
-    wiki_concepts_dir = vault_path / folders_wiki / folders_wiki_concepts
-    if not wiki_concepts_dir.exists() or len(gathered.wiki_notes) >= MAX_CONTEXT_NOTES:
-        return
-
-    existing_titles: set[str] = {n.title.lower() for n in gathered.wiki_notes}
-    for md_file in wiki_concepts_dir.glob("*.md"):
-        body = _strip_frontmatter(md_file.read_text(encoding="utf-8"))
-        if gap.lower() not in body.lower():
-            continue
-
-        frontmatter = _read_frontmatter(md_file)
-        title = str(frontmatter.get("title") or md_file.stem)
-        if title.lower() in existing_titles:
-            continue
-        saved_at = _parse_datetime(frontmatter.get("saved"))
-        note = VaultNoteRecord(
-            path=md_file,
-            relative_path=md_file.relative_to(vault_path).with_suffix("").as_posix(),
-            title=title,
-            saved_at=saved_at,
-            tags=_parse_tags(frontmatter.get("tags")),
-            source_type=str(frontmatter.get("kind")) if frontmatter.get("kind") else None,
-            rating=None,
-            read_time_minutes=None,
-            status=None,
-            canonical_url=None,
-            source=None,
-            vaultmind=bool(frontmatter.get("vaultmind")),
-            body=body,
-            summary=_extract_summary(body),
-            raw_frontmatter=frontmatter,
+    """Search one gap and add bounded, deduplicated wiki/Raw context."""
+    excluded = excluded_wiki_paths or set()
+    all_wiki_notes = [
+        note
+        for note in _load_searchable_wiki_notes(
+            vault_path, folders_wiki, folders_wiki_concepts, folders_wiki_queries
         )
-        gathered.wiki_notes.append(note)
+        if note.relative_path not in excluded
+    ]
+    wiki_matches = search_notes(all_wiki_notes, gap, limit=MAX_CONTEXT_NOTES)
+    existing_wiki = {note.relative_path for note in gathered.wiki_notes}
+    existing_titles = {note.title.casefold() for note in gathered.wiki_notes}
+    added_wiki_matches: list[SearchMatch] = []
+    for match in wiki_matches:
+        if len(gathered.wiki_notes) >= MAX_CONTEXT_NOTES:
+            break
+        if (
+            match.note.relative_path not in existing_wiki
+            and match.note.title.casefold() not in existing_titles
+        ):
+            gathered.wiki_notes.append(match.note)
+            added_wiki_matches.append(match)
+            existing_wiki.add(match.note.relative_path)
+            existing_titles.add(match.note.title.casefold())
+
+    # Only new evidence can satisfy a newly identified gap. A strong result that
+    # was already gathered must not suppress the Raw fallback.
+    if _wiki_context_is_sufficient(added_wiki_matches):
+        return
 
     existing_raw = {source.relative_path for source in gathered.raw_sources}
     for source in _search_raw_sources(gap, vault_path, folders_raw):
-        if source.relative_path not in existing_raw and len(gathered.raw_sources) < MAX_CONTEXT_SOURCES:
+        if len(gathered.raw_sources) >= MAX_CONTEXT_SOURCES:
+            break
+        if source.relative_path not in existing_raw:
             gathered.raw_sources.append(source)
             existing_raw.add(source.relative_path)
 
@@ -369,11 +398,14 @@ def _tokenize_query(query: str) -> set[str]:
 
 
 def _parse_datetime(value: object) -> datetime | None:
-    """Parse a datetime string from frontmatter."""
+    """Parse a datetime value from frontmatter."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
     if not isinstance(value, str):
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
     except ValueError:
         return None
 
@@ -381,11 +413,66 @@ def _parse_datetime(value: object) -> datetime | None:
 # ---- Answer filing ----
 
 
+def _validated_question(question: str) -> str:
+    """Return a single-line non-empty question suitable for an exact H1."""
+    clean = question.strip()
+    if not clean:
+        raise ValueError("question must not be empty")
+    if "\n" in clean or "\r" in clean:
+        raise ValueError("question must be a single line")
+    return clean
+
+
 def _slug_from_question(question: str) -> str:
     """Convert a question string to a query slug for filenames."""
     text = re.sub(r"[^\w\s]", "", question.strip().lower())
     text = re.sub(r"\s+", "-", text)
     return slugify(text)[:60] or "query"
+
+
+def _sanitize_answer_headings(answer: str) -> str:
+    """Demote provider H1/H2 headings without changing fenced examples."""
+    lines = answer.strip().splitlines()
+    sanitized: list[str] = []
+    fence_char: str | None = None
+    fence_length = 0
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if fence_char is not None:
+            sanitized.append(line)
+            closing = re.match(rf"^ {{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*$", line)
+            if closing:
+                fence_char = None
+                fence_length = 0
+            index += 1
+            continue
+
+        opening = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", line)
+        if opening:
+            marker = opening.group(1)
+            info = opening.group(2)
+            # CommonMark only prohibits backticks in backtick-fence info strings.
+            if marker[0] == "~" or "`" not in info:
+                fence_char = marker[0]
+                fence_length = len(marker)
+                sanitized.append(line)
+                index += 1
+                continue
+
+        if index + 1 < len(lines) and line.strip():
+            setext = re.match(r"^ {0,3}(?:=+|-+)[ \t]*$", lines[index + 1])
+            if setext:
+                indent = line[: len(line) - len(line.lstrip(" "))]
+                sanitized.append(f"{indent}### {line.strip()}")
+                index += 2
+                continue
+
+        sanitized.append(re.sub(r"^( {0,3})#{1,2}[ \t]+", r"\1### ", line))
+        index += 1
+
+    return "\n".join(sanitized)
 
 
 def _render_answer_markdown(
@@ -396,28 +483,42 @@ def _render_answer_markdown(
     supporting_sources: list[str],
     iterations: int,
     now: datetime,
+    gaps: list[str] | None = None,
 ) -> str:
-    """Render the full markdown body for an answer page."""
+    """Render a query page that deterministically satisfies the page contract."""
+    # Provider output is content, not page structure. Demoting headings prevents it
+    # from introducing another H1 or colliding with the required H2 sections.
+    safe_answer = _sanitize_answer_headings(answer)
+    safe_question = _validated_question(question)
+    safe_notes = [" ".join(path.split()) for path in supporting_notes]
+    safe_sources = [" ".join(source.split()) for source in supporting_sources]
+    safe_gaps = [" ".join(gap.split()) for gap in gaps or []]
     lines = [
-        f"# {question}",
+        f"# {safe_question}",
         "",
-        "## 💡 Answer",
-        answer.strip(),
+        "## Answer",
+        safe_answer,
         "",
-        "## Supporting Notes",
+        "## Supporting Wiki Pages",
     ]
-    if supporting_notes:
-        for path in supporting_notes:
+    if safe_notes:
+        for path in safe_notes:
             lines.append(f"- [[{path}]]")
     else:
-        lines.append("*No wiki notes used.*")
+        lines.append("*No wiki pages used.*")
 
-    lines.extend(["", "## Supporting Sources"])
-    if supporting_sources:
-        for source in supporting_sources:
+    lines.extend(["", "## Supporting Raw Sources"])
+    if safe_sources:
+        for source in safe_sources:
             lines.append(f"- {source}")
     else:
         lines.append("*No raw sources used.*")
+
+    lines.extend(["", "## Follow-up Questions"])
+    if safe_gaps:
+        lines.extend(f"- {gap}" for gap in safe_gaps)
+    else:
+        lines.append("*No follow-up questions.*")
 
     lines.extend([
         "",
@@ -447,79 +548,86 @@ async def ask_question(
     The answer is written to Wiki/📊 Queries/{slug}.md so future questions
     can read it and build on it — this is the compound interest engine.
     """
+    question = _validated_question(question)
     max_iters = 1 if depth == "shallow" else MAX_ITERATIONS
+    slug = _slug_from_question(question)
+    query_relative_path = (
+        Path(folders_wiki) / folders_wiki_queries / slug
+    ).as_posix()
+    excluded_wiki_paths = {query_relative_path}
 
-    gathered = _initial_search(question, vault_path, folders_wiki, folders_wiki_concepts, folders_raw)
+    gathered = _initial_search(
+        question,
+        vault_path,
+        folders_wiki,
+        folders_wiki_concepts,
+        folders_raw,
+        folders_wiki_queries,
+        excluded_wiki_paths,
+    )
     log.info("ask_initial_search", wiki=len(gathered.wiki_notes), raw=len(gathered.raw_sources))
 
-    note_paths_used: set[str] = set()
-    source_urls_used: set[str] = set()
-    for note in gathered.wiki_notes:
-        note_paths_used.add(note.relative_path)
-    for source in gathered.raw_sources:
-        source_urls_used.add(source.source_url or source.relative_path)
-
-    context = _build_context_text(question, gathered)
-    user_prompt = ASK_USER_PROMPT.format(question=question, context=context)
-
-    try:
-        response = await provider.complete(user_prompt, system=ASK_SYSTEM_PROMPT)
-    except Exception as exc:
-        log.error("ask_llm_failed", error=str(exc))
-        raise
-
-    answer = _extract_answer_text(response)
-    iteration = 1
+    answer = ""
+    iteration = 0
     gaps: list[str] = []
 
-    if iteration < max_iters:
-        assess_prompt = ASK_SELF_ASSESS_PROMPT.format(question=question, answer=response)
+    while iteration < max_iters:
+        context = _build_context_text(question, gathered)
+        user_prompt = ASK_USER_PROMPT.format(question=question, context=context)
+        try:
+            response = await provider.complete(user_prompt, system=ASK_SYSTEM_PROMPT)
+        except Exception as exc:
+            log.error("ask_llm_failed", iteration=iteration + 1, error=str(exc))
+            raise
+
+        answer = _extract_answer_text(response)
+        iteration += 1
+
+        # Shallow mode deliberately makes exactly one provider call.
+        if depth == "shallow":
+            break
+
+        assess_prompt = ASK_SELF_ASSESS_PROMPT.format(question=question, answer=answer)
         try:
             assessment = await provider.complete(assess_prompt, system=ASK_SYSTEM_PROMPT)
             gaps = _extract_gaps_from_assessment(assessment)
         except Exception as exc:
-            log.warning("ask_self_assess_failed", error=str(exc))
+            log.warning("ask_self_assess_failed", iteration=iteration, error=str(exc))
             gaps = []
 
-        if gaps:
-            log.info("ask_follow_up", iteration=iteration, gaps=gaps)
-            for gap in gaps:
-                _follow_up_gap(gap, gathered, vault_path, folders_wiki, folders_wiki_concepts, folders_raw)
-
-            note_paths_used.clear()
-            for note in gathered.wiki_notes:
-                note_paths_used.add(note.relative_path)
-            source_urls_used.clear()
-            for source in gathered.raw_sources:
-                source_urls_used.add(source.source_url or source.relative_path)
-
-            gathered.wiki_notes = gathered.wiki_notes[:MAX_CONTEXT_NOTES]
-            context = _build_context_text(question, gathered)
-            user_prompt = ASK_USER_PROMPT.format(question=question, context=context)
-            response = await provider.complete(user_prompt, system=ASK_SYSTEM_PROMPT)
-            answer = _extract_answer_text(response)
-            iteration = 2
-
-            if iteration < max_iters:
-                assess_prompt = ASK_SELF_ASSESS_PROMPT.format(question=question, answer=response)
-                try:
-                    assessment = await provider.complete(assess_prompt, system=ASK_SYSTEM_PROMPT)
-                    gaps = _extract_gaps_from_assessment(assessment)
-                except Exception:
-                    gaps = []
-        else:
+        if not gaps:
             log.info("ask_no_gaps", iteration=iteration)
+            break
+        if iteration >= max_iters:
+            break
 
-    slug = _slug_from_question(question)
+        log.info("ask_follow_up", iteration=iteration, gaps=gaps)
+        for gap in gaps:
+            _follow_up_gap(
+                gap,
+                gathered,
+                vault_path,
+                folders_wiki,
+                folders_wiki_concepts,
+                folders_raw,
+                folders_wiki_queries,
+                excluded_wiki_paths,
+            )
+
     now = datetime.now(UTC)
 
+    note_paths_used = sorted({note.relative_path for note in gathered.wiki_notes})
+    source_urls_used = sorted(
+        {source.source_url or source.relative_path for source in gathered.raw_sources}
+    )
     body = _render_answer_markdown(
         question,
         answer,
-        supporting_notes=sorted(note_paths_used),
-        supporting_sources=sorted(source_urls_used),
+        supporting_notes=note_paths_used,
+        supporting_sources=source_urls_used,
         iterations=iteration,
         now=now,
+        gaps=gaps,
     )
 
     queries_dir = vault_path / folders_wiki / folders_wiki_queries

--- a/src/vaultmind/ai/compiler.py
+++ b/src/vaultmind/ai/compiler.py
@@ -1,9 +1,13 @@
 """Compile pipeline — sources to wiki concept articles.
 
 Three stages:
-1. Concept triage — extract concepts from new/changed sources
-2. Article create/update — LLM writes or updates concept articles
-3. Index rebuild — update Wiki/📇 Index.md
+1. Concept triage — extract concepts from new/changed sources.
+2. Article create/update — LLM writes or updates concept articles.
+3. Cross-page propagation — patch existing concept pages so they cross-link
+   to the new/updated concepts (Connections + Sources only).
+
+Index rebuild lives in vaultmind.commands.compile (it depends on the manifest
+state assembled at the command layer, not on this module).
 """
 
 from __future__ import annotations
@@ -11,10 +15,11 @@ from __future__ import annotations
 __all__ = ["CompileResult", "compile_sources", "rebuild_index"]
 
 import asyncio
+import hashlib
 import json
 import re
 import unicodedata
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import structlog
@@ -25,15 +30,14 @@ from vaultmind.ai.prompts import (
     COMPILE_ARTICLE_UPDATE_PROMPT,
     COMPILE_CONCEPT_DEDUP_PROMPT,
     COMPILE_CONCEPT_TRIAGE_PROMPT,
+    COMPILE_GRAPH_TOUCH_PROMPT,
     COMPILE_INDEX_REBUILD_PROMPT,
 )
 from vaultmind.ai.providers.base import Provider
 from vaultmind.config import FolderConfig
-from vaultmind.core.raw_scanner import (
-    RawSourceRecord,
-    _strip_broken_images,
-    format_raw_source_packet,
-)
+from vaultmind.core.linter import extract_wikilinks
+from vaultmind.core.raw_scanner import RawSourceRecord, format_raw_source_packet
+from vaultmind.core.writer import write_markdown_page
 from vaultmind.schemas import ConceptStatus, Manifest, WikiConceptEntry
 
 log = structlog.get_logger()
@@ -47,6 +51,9 @@ class CompileResult:
     articles_updated: int
     sources_compiled: int
     errors: list[str]
+    articles_touched: int = 0
+    propagation_touches_by_source: dict[str, list[str]] = field(default_factory=dict)
+    propagation_failed_sources: set[str] = field(default_factory=set)
 
 
 def _extract_h1_title(body: str) -> str | None:
@@ -55,27 +62,111 @@ def _extract_h1_title(body: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def _strip_h1(body: str) -> str:
-    """Remove the first H1 heading from a markdown body."""
-    lines = body.splitlines()
-    if lines and re.match(r"^#\s+", lines[0]):
-        return "\n".join(lines[1:]).lstrip("\n")
+def _markdown_line_text(line: str) -> str:
+    """Remove only a line ending, retaining all Markdown-significant whitespace."""
+    return line[:-2] if line.endswith("\r\n") else line[:-1] if line.endswith("\n") else line
+
+
+def _strip_model_frontmatter(body: str) -> str:
+    """Remove leading model-authored YAML frontmatter, including CRLF form."""
+    lines = body.splitlines(keepends=True)
+    if not lines:
+        return body
+
+    opening_index = 0
+    while opening_index < len(lines) and not _markdown_line_text(lines[opening_index]).strip():
+        opening_index += 1
+    if opening_index == len(lines) or not re.fullmatch(
+        r"---[ \t]*", _markdown_line_text(lines[opening_index])
+    ):
+        return body
+
+    for closing_index in range(opening_index + 1, len(lines)):
+        if re.fullmatch(r"---[ \t]*", _markdown_line_text(lines[closing_index])):
+            return "".join(lines[:opening_index] + lines[closing_index + 1 :])
     return body
 
 
-def _extract_frontmatter(markdown: str) -> dict[str, object]:
-    """Extract a markdown frontmatter block as a mapping."""
-    if not markdown.startswith("---"):
-        return {}
+def _strip_model_page_wrappers(body: str) -> str:
+    """Remove model metadata and real H1s with Markdown fence awareness.
 
-    end = markdown.find("---", 3)
-    if end == -1:
+    Original line endings, indentation, and all non-wrapper content are kept.
+    Fences follow CommonMark's relevant rules: 0--3 leading spaces, matching
+    backtick/tilde marker, and a closing run at least as long as the opener
+    followed only by whitespace.
+    """
+    cleaned = _strip_model_frontmatter(body)
+    lines = cleaned.splitlines(keepends=True)
+    remove: set[int] = set()
+    outside: list[bool] = [False] * len(lines)
+    fence_char: str | None = None
+    fence_length = 0
+
+    for index, line in enumerate(lines):
+        text = _markdown_line_text(line)
+        outside[index] = fence_char is None
+        if fence_char is not None:
+            closer = re.fullmatch(rf" {{0,3}}({re.escape(fence_char)}+)[ \t]*", text)
+            if closer and len(closer.group(1)) >= fence_length:
+                fence_char = None
+                fence_length = 0
+            continue
+
+        opener = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", text)
+        if opener:
+            marker, remainder = opener.groups()
+            # A backtick fence's info string cannot itself contain a backtick.
+            if marker[0] == "~" or "`" not in remainder:
+                fence_char = marker[0]
+                fence_length = len(marker)
+                continue
+
+        if re.match(r"^ {0,3}#(?:[ \t]+|$)", text):
+            remove.add(index)
+            continue
+
+        if not re.fullmatch(r" {0,3}=+[ \t]*", text) or index == 0:
+            continue
+        previous = _markdown_line_text(lines[index - 1])
+        previous_indent = len(previous) - len(previous.lstrip(" "))
+        if (
+            outside[index - 1]
+            and index - 1 not in remove
+            and previous.strip()
+            and previous_indent <= 3
+            and not re.match(r"^ {0,3}(?:#{1,6}(?:[ \t]+|$)|>|[-+*][ \t]+)", previous)
+        ):
+            remove.update((index - 1, index))
+
+    return "".join(line for index, line in enumerate(lines) if index not in remove)
+
+
+def _frontmatter_span(markdown: str) -> tuple[int, int, int] | None:
+    """Return YAML content and body offsets for line-delimited frontmatter."""
+    lines = markdown.splitlines(keepends=True)
+    if not lines or not re.fullmatch(r"---[ \t]*", _markdown_line_text(lines[0])):
+        return None
+
+    offset = len(lines[0])
+    for line in lines[1:]:
+        line_start = offset
+        offset += len(line)
+        if re.fullmatch(r"---[ \t]*", _markdown_line_text(line)):
+            return len(lines[0]), line_start, offset
+    return None
+
+
+def _extract_frontmatter(markdown: str) -> dict[str, object]:
+    """Extract a line-delimited markdown frontmatter block as a mapping."""
+    span = _frontmatter_span(markdown)
+    if span is None:
         return {}
+    content_start, content_end, _body_start = span
 
     try:
         import yaml
 
-        data = yaml.safe_load(markdown[3:end])
+        data = yaml.safe_load(markdown[content_start:content_end])
     except yaml.YAMLError:
         return {}
 
@@ -112,10 +203,11 @@ def _merge_source_urls(*source_groups: list[str]) -> list[str]:
     seen: set[str] = set()
     for group in source_groups:
         for source in group:
-            if source in seen:
+            normalized = source.strip()
+            if not normalized or normalized in seen:
                 continue
-            seen.add(source)
-            merged.append(source)
+            seen.add(normalized)
+            merged.append(normalized)
     return merged
 
 
@@ -141,6 +233,7 @@ async def compile_sources(
     *,
     dry_run: bool = False,
     existing_concepts: list[tuple[str, str]] | None = None,
+    max_touches: int = 5,
 ) -> tuple[CompileResult, dict[str, list[str]]]:
     """Run the full compile pipeline on raw source documents.
 
@@ -190,40 +283,73 @@ async def compile_sources(
         concepts = await _deduplicate_concepts(concepts, provider)
         log.info("compile_dedup_done", concepts=len(concepts))
 
+    # Accept attribution once, before any article prompt or page is generated.
+    # All later artifacts consume these same ordered references.
+    concepts = [
+        concept.model_copy(
+            update={
+                "source_urls": _bounded_source_references(
+                    concept.source_urls,
+                    context=f"concept:{concept.name}",
+                    preferred_keys=set(url_to_source),
+                )
+            }
+        )
+        for concept in concepts
+    ]
+
     # Stage 2: create or update each article — all run concurrently
-    async def _process_concept(concept: WikiConceptEntry) -> tuple[str, str, bool, bool]:
-        """Process a single concept, return (slug, target_slug, was_created, was_updated)."""
+    async def _process_concept(
+        concept: WikiConceptEntry,
+    ) -> tuple[str, str, bool, bool, list[str]]:
+        """Process a concept and return its exact accepted attribution list."""
         slug = slugify(concept.name)
 
         if concept.status == ConceptStatus.NEW:
             if dry_run:
                 log.info("compile_dry_run_create", concept=concept.name)
-                return (slug, slug, False, False)
-            await _create_and_write_article(slug, concept, provider, vault_path, folders)
+                return (slug, slug, False, False, concept.source_urls)
+            await _create_and_write_article(
+                slug, concept, url_to_source, provider, vault_path, folders
+            )
             log.info("compile_article_done", slug=slug, status="created")
-            return (slug, slug, True, False)
+            return (slug, slug, True, False, concept.source_urls)
 
         # EXISTING or MERGE
         target_slug = concept.merge_target or slug
         if dry_run:
             log.info("compile_dry_run_update", concept=concept.name, target=target_slug)
-            return (slug, target_slug, False, False)
+            return (slug, target_slug, False, False, concept.source_urls)
 
         existing_content = _read_wiki_article_content(manifest, target_slug, vault_path, folders)
         if existing_content:
+            accepted_sources = _merge_accepted_source_references(
+                _extract_frontmatter_sources(existing_content),
+                concept.source_urls,
+                context=f"article:{target_slug}",
+            )
+            accepted_concept = concept.model_copy(update={"source_urls": accepted_sources})
             await _update_and_write_article(
-                target_slug, existing_content, concept, url_to_source, provider, vault_path, folders
+                target_slug,
+                existing_content,
+                accepted_concept,
+                url_to_source,
+                provider,
+                vault_path,
+                folders,
             )
             log.info("compile_article_done", slug=target_slug, status="updated")
-            return (slug, target_slug, False, True)
+            return (slug, target_slug, False, True, accepted_sources)
         else:
-            await _create_and_write_article(target_slug, concept, provider, vault_path, folders)
+            await _create_and_write_article(
+                target_slug, concept, url_to_source, provider, vault_path, folders
+            )
             log.info("compile_article_done", slug=target_slug, status="created_new")
-            return (slug, target_slug, True, False)
+            return (slug, target_slug, True, False, concept.source_urls)
 
     async def _process_concept_with_error_handling(
         concept: WikiConceptEntry,
-    ) -> tuple[str, str, bool, bool] | None:
+    ) -> tuple[str, str, bool, bool, list[str]] | None:
         """Wrap _process_concept to attach concept name to any exceptions."""
         try:
             return await _process_concept(concept)
@@ -238,17 +364,26 @@ async def compile_sources(
     for item in processed:
         if item is None:
             continue
-        slug, target_slug, was_created, was_updated = item
+        _slug, target_slug, was_created, was_updated, accepted_sources = item
         result.articles_created += was_created
         result.articles_updated += was_updated
-        # Accumulate source URLs — deduplicate to avoid repeated manifest entries
-        concept = next((c for c in concepts if slugify(c.name) == slug), None)
-        if concept:
-            if target_slug not in slug_to_urls:
-                slug_to_urls[target_slug] = []
-            for url in concept.source_urls:
-                if url not in slug_to_urls[target_slug]:
-                    slug_to_urls[target_slug].append(url)
+        slug_to_urls[target_slug] = _bounded_source_references(
+            _merge_source_urls(slug_to_urls.get(target_slug, []), accepted_sources),
+            context=f"slug:{target_slug}",
+        )
+
+    # Stage 3: cross-page propagation — patch existing concept pages so they
+    # cross-link to the new/updated concepts.
+    if not dry_run and slug_to_urls and max_touches > 0:
+        await _propagate_to_existing_concepts(
+            sources=sources,
+            slug_to_urls=slug_to_urls,
+            provider=provider,
+            vault_path=vault_path,
+            folders=folders,
+            max_touches=max_touches,
+            result=result,
+        )
 
     return result, slug_to_urls
 
@@ -260,21 +395,212 @@ def _format_existing_concepts(existing_concepts: list[tuple[str, str]]) -> str:
     return "\n".join(f"- {slug}: {title}" for slug, title in sorted(existing_concepts))
 
 
+# Bounds cover both the complete article prompt and its independently useful
+# components. The formatter never enforces these by slicing a completed packet:
+# doing so can leave packet metadata but remove all original body text.
+ARTICLE_SOURCE_PER_SOURCE_CHARS = 6000
+ARTICLE_SOURCE_TOTAL_CHARS = 24000
+ARTICLE_SOURCE_REFERENCE_LIMIT = 64
+ARTICLE_EXISTING_CONTENT_CHARS = 24000
+ARTICLE_PROMPT_TOTAL_CHARS = 50000
+ARTICLE_DESCRIPTION_CHARS = 4000
+ARTICLE_CONCEPT_NAME_CHARS = 500
+_SOURCE_LABEL_CHARS = 256
+_SOURCE_PACKET_MIN_CHARS = 96
+
+
+def _bounded_source_references(
+    source_keys: list[str],
+    *,
+    context: str,
+    preferred_keys: set[str] | None = None,
+) -> list[str]:
+    """Deduplicate and cap attribution, retaining resolvable keys first."""
+    deduplicated = _merge_source_urls(source_keys)
+    if preferred_keys:
+        preferred = [key for key in deduplicated if key in preferred_keys]
+        remaining = [key for key in deduplicated if key not in preferred_keys]
+        deduplicated = [*preferred, *remaining]
+    retained = deduplicated[:ARTICLE_SOURCE_REFERENCE_LIMIT]
+    if len(retained) < len(deduplicated):
+        log.warning(
+            "article_source_references_truncated",
+            context=context,
+            accepted=len(retained),
+            dropped=len(deduplicated) - len(retained),
+            limit=ARTICLE_SOURCE_REFERENCE_LIMIT,
+        )
+    return retained
+
+
+def _merge_accepted_source_references(
+    existing: list[str],
+    incoming: list[str],
+    *,
+    context: str,
+) -> list[str]:
+    """Bound attribution while reserving room for every accepted incoming key."""
+    accepted_incoming = _bounded_source_references(incoming, context=f"{context}:incoming")
+    incoming_set = set(accepted_incoming)
+    prior = [key for key in _merge_source_urls(existing) if key not in incoming_set]
+    prior_capacity = ARTICLE_SOURCE_REFERENCE_LIMIT - len(accepted_incoming)
+    combined = [*prior[:prior_capacity], *accepted_incoming]
+    dropped = len(prior) - prior_capacity
+    if dropped > 0:
+        log.warning(
+            "article_source_references_truncated",
+            context=context,
+            accepted=len(combined),
+            dropped=dropped,
+            limit=ARTICLE_SOURCE_REFERENCE_LIMIT,
+        )
+    return combined
+
+
+def _truncate_with_marker(value: str, max_chars: int, marker: str = "…") -> str:
+    """Bound text to exactly ``max_chars`` at most, including its marker."""
+    if len(value) <= max_chars:
+        return value
+    if max_chars <= len(marker):
+        return marker[:max_chars]
+    return value[: max_chars - len(marker)].rstrip() + marker
+
+
+def _source_label(key: str, max_chars: int = _SOURCE_LABEL_CHARS) -> str:
+    """Return a bounded, stable representation of an attributed source key."""
+    if len(key) <= max_chars:
+        return key
+    digest = hashlib.sha256(key.encode()).hexdigest()[:12]
+    suffix = f"… [sha256:{digest}]"
+    if max_chars <= len(suffix):
+        return ("~" + digest)[:max_chars]
+    return _truncate_with_marker(key, max_chars - len(suffix), "") + suffix
+
+
+def _bounded_raw_source_packet(source: RawSourceRecord, packet_chars: int) -> str:
+    """Format a packet that always contains a non-empty Raw body field."""
+    key = _source_key(source)
+    metadata = (
+        f"Title: {_truncate_with_marker(source.title, 160)}\n"
+        f"Source: {_source_label(key)}\n"
+        f"Tags: {_truncate_with_marker(', '.join(source.raw_tags) or 'none', 160)}\n\n"
+        "Raw body:\n"
+    )
+    body_budget = max(1, packet_chars - len(metadata))
+    body = _truncate_with_marker(source.body or "[Empty Raw body]", body_budget)
+    packet = metadata + body
+    if len(packet) <= packet_chars:
+        return packet
+
+    # Tiny budgets still retain the semantic packet invariant instead of
+    # returning an arbitrary metadata prefix.
+    minimal_prefix = "Raw body:\n"
+    return minimal_prefix + _truncate_with_marker(
+        source.body or "[Empty Raw body]", max(1, packet_chars - len(minimal_prefix))
+    )
+
+
+def _format_article_source_context(
+    source_keys: list[str],
+    url_to_source: dict[str, RawSourceRecord],
+    *,
+    max_chars: int = ARTICLE_SOURCE_TOTAL_CHARS,
+) -> str:
+    """Format attributed citations and as many complete Raw packets as fit.
+
+    Every key has a stable citation representation. Long keys use a readable
+    prefix plus digest. Resolved packets are retained only when enough room
+    remains for their ``Raw body`` field; unresolved citations remain visible
+    even when their optional unavailable packet does not fit.
+    """
+    max_chars = min(max_chars, ARTICLE_SOURCE_TOTAL_CHARS)
+    keys = _bounded_source_references(
+        source_keys,
+        context="source_context",
+        preferred_keys=set(url_to_source),
+    )
+    if not keys:
+        return _truncate_with_marker("No attributed sources.", max_chars)
+
+    header = "Attributed source citations:\n"
+    packet_header = "\n\nRaw source packets:\n"
+    per_label = min(
+        _SOURCE_LABEL_CHARS,
+        max(18, (max_chars - len(header) - len(packet_header) - 3 * len(keys)) // len(keys)),
+    )
+    citation_lines = [f"- {_source_label(key, per_label)}" for key in keys]
+    citations = header + "\n".join(citation_lines)
+
+    # ARTICLE_SOURCE_REFERENCE_LIMIT guarantees this fits the normal hard
+    # context bound while keeping every retained key individually identifiable.
+    if len(citations) + len(packet_header) > max_chars:
+        raise ValueError("source context budget is too small for accepted attribution labels")
+
+    prefix = citations + packet_header
+    remaining = max_chars - len(prefix)
+    separator = "\n\n---\n\n"
+    packets: list[str] = []
+
+    resolved = [url_to_source[key] for key in keys if key in url_to_source]
+    separator_chars = len(separator)
+    capacity = max(0, (remaining + separator_chars) // (_SOURCE_PACKET_MIN_CHARS + separator_chars))
+    retained = resolved[:capacity]
+    resolved_reserve = len(retained) * (_SOURCE_PACKET_MIN_CHARS + separator_chars)
+
+    # Preserve explicit unavailable markers only after reserving body-bearing
+    # packets. Their citation lines above already carry the attribution.
+    for key in keys:
+        if key in url_to_source:
+            continue
+        candidate = f"Source: {_source_label(key)}\n\n[Raw source unavailable]"
+        needed = len(candidate) + (len(separator) if packets else 0)
+        if needed + resolved_reserve <= remaining:
+            packets.append(candidate)
+            remaining -= needed
+
+    for index, source in enumerate(retained):
+        sources_left = len(retained) - index
+        separator_cost = separator_chars if packets else 0
+        future_separators = separator_chars * max(0, sources_left - 1)
+        available = min(
+            ARTICLE_SOURCE_PER_SOURCE_CHARS,
+            (remaining - separator_cost - future_separators) // sources_left,
+        )
+        packet = _bounded_raw_source_packet(source, available)
+        packets.append(packet)
+        remaining -= len(packet) + separator_cost
+
+    return prefix + separator.join(packets)
+
+
 async def _create_article(
     concept: WikiConceptEntry,
+    url_to_source: dict[str, RawSourceRecord],
     provider: Provider,
 ) -> str:
-    """LLM call to create a new wiki article from a concept."""
-    source_urls_str = "\n".join(f"- {url}" for url in concept.source_urls)
-    prompt = COMPILE_ARTICLE_CREATE_PROMPT.format(
-        concept_name=concept.name,
-        description=concept.description,
-        source_urls=source_urls_str,
+    """LLM call to create a new wiki article from grounded Raw sources."""
+    concept_name = _truncate_with_marker(concept.name, ARTICLE_CONCEPT_NAME_CHARS)
+    description = _truncate_with_marker(concept.description, ARTICLE_DESCRIPTION_CHARS)
+    prompt_without_sources = COMPILE_ARTICLE_CREATE_PROMPT.format(
+        concept_name=concept_name,
+        description=description,
+        source_context="",
     )
+    source_context = _format_article_source_context(
+        concept.source_urls,
+        url_to_source,
+        max_chars=ARTICLE_PROMPT_TOTAL_CHARS - len(prompt_without_sources),
+    )
+    prompt = COMPILE_ARTICLE_CREATE_PROMPT.format(
+        concept_name=concept_name,
+        description=description,
+        source_context=source_context,
+    )
+    assert len(prompt) <= ARTICLE_PROMPT_TOTAL_CHARS
 
     wiki_author = "You are a research wiki author. Write markdown only."
     response = await provider.complete(prompt, system=wiki_author)
-    return response.strip()
+    return response
 
 
 async def _update_article(
@@ -284,40 +610,41 @@ async def _update_article(
     provider: Provider,
 ) -> str:
     """LLM call to update an existing wiki article with new source info."""
-    source_blocks: list[str] = []
-    for url in concept.source_urls:
-        source = url_to_source.get(url)
-        if source:
-            # Strip broken CDN images from source body
-            clean_body = _strip_broken_images(source.body[:800])
-            source_blocks.append(f"Source: {url}\n\n{clean_body}")
-        else:
-            source_blocks.append(f"Source: {url}")
-
-    if source_blocks:
-        source_urls_str = "\n\n".join(source_blocks)
-    else:
-        source_urls_str = "\n".join(f"- {url}" for url in concept.source_urls)
-
-    prompt = COMPILE_ARTICLE_UPDATE_PROMPT.format(
-        existing_content=existing_content,
-        new_sources=source_urls_str,
+    bounded_existing = _truncate_with_marker(
+        existing_content,
+        ARTICLE_EXISTING_CONTENT_CHARS,
+        "\n\n[Existing article truncated]",
     )
+    prompt_without_sources = COMPILE_ARTICLE_UPDATE_PROMPT.format(
+        existing_content=bounded_existing,
+        new_sources="",
+    )
+    source_context = _format_article_source_context(
+        concept.source_urls,
+        url_to_source,
+        max_chars=ARTICLE_PROMPT_TOTAL_CHARS - len(prompt_without_sources),
+    )
+    prompt = COMPILE_ARTICLE_UPDATE_PROMPT.format(
+        existing_content=bounded_existing,
+        new_sources=source_context,
+    )
+    assert len(prompt) <= ARTICLE_PROMPT_TOTAL_CHARS
 
     wiki_author = "You are a research wiki author. Write markdown only."
     response = await provider.complete(prompt, system=wiki_author)
-    return response.strip()
+    return response
 
 
 async def _create_and_write_article(
     slug: str,
     concept: WikiConceptEntry,
+    url_to_source: dict[str, RawSourceRecord],
     provider: Provider,
     vault_path: Path,
     folders: FolderConfig,
 ) -> None:
     """Create a wiki article via LLM and write it to disk."""
-    body = await _create_article(concept, provider)
+    body = await _create_article(concept, url_to_source, provider)
     _write_wiki_article(slug, body, concept.name, concept.source_urls, vault_path, folders)
 
 
@@ -337,11 +664,146 @@ async def _update_and_write_article(
         or _extract_h1_title(existing_content)
         or slug.replace("-", " ").title()
     )
-    source_urls = _merge_source_urls(
-        _extract_frontmatter_sources(existing_content),
-        concept.source_urls,
-    )
-    _write_wiki_article(slug, body, title, source_urls, vault_path, folders)
+    _write_wiki_article(slug, body, title, concept.source_urls, vault_path, folders)
+
+
+REQUIRED_CONCEPT_SECTIONS = (
+    "Overview",
+    "Key Ideas",
+    "Connections",
+    "Open Questions",
+    "Sources",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _MarkdownSection:
+    """An H2 and its content span, excluding fenced fake headings."""
+
+    title: str
+    start: int
+    content_start: int
+    end: int
+
+
+def _markdown_h2_sections(body: str) -> list[_MarkdownSection]:
+    """Locate real H2 sections with CommonMark-style fence awareness."""
+    headings: list[tuple[str, int, int]] = []
+    fence_char: str | None = None
+    fence_length = 0
+    offset = 0
+    for line in body.splitlines(keepends=True):
+        text = _markdown_line_text(line)
+        if fence_char is not None:
+            closer = re.fullmatch(rf" {{0,3}}({re.escape(fence_char)}+)[ \t]*", text)
+            if closer and len(closer.group(1)) >= fence_length:
+                fence_char = None
+                fence_length = 0
+            offset += len(line)
+            continue
+
+        opener = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", text)
+        if opener:
+            marker, remainder = opener.groups()
+            if marker[0] == "~" or "`" not in remainder:
+                fence_char = marker[0]
+                fence_length = len(marker)
+                offset += len(line)
+                continue
+
+        heading = re.match(r"^ {0,3}##[ \t]+(.+?)[ \t]*#*[ \t]*$", text)
+        if heading:
+            headings.append((heading.group(1).strip(), offset, offset + len(line)))
+        offset += len(line)
+
+    return [
+        _MarkdownSection(
+            title=title,
+            start=start,
+            content_start=content_start,
+            end=headings[index + 1][1] if index + 1 < len(headings) else len(body),
+        )
+        for index, (title, start, content_start) in enumerate(headings)
+    ]
+
+
+def _ensure_required_sections(body: str) -> str:
+    """Add missing real concept sections without trusting fenced headings."""
+    result = body
+    for index in range(len(REQUIRED_CONCEPT_SECTIONS) - 1, -1, -1):
+        heading = REQUIRED_CONCEPT_SECTIONS[index]
+        if any(section.title == heading for section in _markdown_h2_sections(result)):
+            continue
+        later_headings = list(REQUIRED_CONCEPT_SECTIONS[index + 1:])
+        section = f"## {heading}\n"
+        result = _insert_section_before(result, section, later_headings)
+    return result
+
+
+def _without_source_bullets(content: str) -> str:
+    """Remove model-authored source bullets outside fenced regions."""
+    retained: list[str] = []
+    fence_char: str | None = None
+    fence_length = 0
+    for line in content.splitlines():
+        if fence_char is not None:
+            closer = re.fullmatch(rf" {{0,3}}({re.escape(fence_char)}+)[ \t]*", line)
+            if closer and len(closer.group(1)) >= fence_length:
+                fence_char = None
+                fence_length = 0
+            retained.append(line)
+            continue
+
+        opener = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", line)
+        if opener:
+            marker, remainder = opener.groups()
+            if marker[0] == "~" or "`" not in remainder:
+                fence_char = marker[0]
+                fence_length = len(marker)
+                retained.append(line)
+                continue
+        if re.match(r"^\s*[-*+]\s+", line):
+            continue
+        retained.append(line)
+    return "\n".join(retained).strip()
+
+
+def _synchronize_sources_section(body: str, sources: list[str]) -> str:
+    """Consolidate real Sources sections and emit managed citations once."""
+    sections = [section for section in _markdown_h2_sections(body) if section.title == "Sources"]
+    if not sections:  # Defensive: required-section enforcement normally adds it.
+        return _append_section(body, "## Sources\n\n" + "\n".join(f"- {s}" for s in sources))
+
+    retained = [
+        content
+        for section in sections
+        if (content := _without_source_bullets(body[section.content_start:section.end]))
+    ]
+    canonical = "\n".join(f"- {source}" for source in sources)
+    section_parts = [*retained, *([canonical] if canonical else [])]
+    replacement = "## Sources\n\n" + "\n\n".join(section_parts) + "\n"
+
+    # Replace the first section and remove every duplicate, working backwards
+    # so the parser's original offsets remain valid.
+    result = body
+    for section in reversed(sections[1:]):
+        result = result[:section.start] + result[section.end:]
+    first = sections[0]
+    return result[:first.start] + replacement + result[first.end:]
+
+
+def _single_line_title(title: str, fallback: str = "Untitled Concept") -> str:
+    """Collapse an untrusted title to one non-empty Markdown heading line."""
+    normalized = re.sub(r"\s+", " ", title).strip()
+    return normalized or fallback
+
+
+def _normalize_concept_body(body: str, title: str, sources: list[str]) -> str:
+    """Enforce the deterministic body portion of the concept-page contract."""
+    model_content = _strip_model_page_wrappers(body)
+    model_content = _ensure_required_sections(model_content)
+    model_content = _synchronize_sources_section(model_content, sources)
+    return f"# {_single_line_title(title)}\n\n{model_content}"
 
 
 def _write_wiki_article(
@@ -358,35 +820,45 @@ def _write_wiki_article(
 
     article_path = wiki_concepts_dir / f"{slug}.md"
 
-    content_body = _strip_h1(body)
+    accepted_sources = _bounded_source_references(
+        source_urls,
+        context=f"page:{slug}",
+    )
+    safe_title = _single_line_title(title, slug.replace("-", " ").title())
+    content_body = _normalize_concept_body(body, safe_title, accepted_sources)
+    import yaml
+
+    class _IndentedSafeDumper(yaml.SafeDumper):
+        def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
+            return super().increase_indent(flow, False)
 
     frontmatter = {
-        "title": title,
+        "title": safe_title,
         "vaultmind": True,
         "kind": "concept",
-        "sources": source_urls,
+        "sources": accepted_sources,
     }
-    fm_lines = ["---"]
-    for k, v in frontmatter.items():
-        if isinstance(v, list):
-            fm_lines.append(f"{k}:")
-            for item in v:
-                fm_lines.append(f"  - {item}")
-        else:
-            fm_lines.append(f"{k}: {v}")
-    fm_lines.append("---")
-    frontmatter_str = "\n".join(fm_lines)
+    serialized_frontmatter = yaml.dump(
+        frontmatter,
+        Dumper=_IndentedSafeDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    ).rstrip()
+    content_body = content_body.rstrip("\r\n")
+    content = f"---\n{serialized_frontmatter}\n---\n\n{content_body}\n"
 
-    content = f"{frontmatter_str}\n\n{content_body.strip()}\n"
-
+    # Match core.writer's same-directory temporary file + atomic replace
+    # convention while retaining the established indented source-list format.
     import tempfile
-    fd, tmp = tempfile.mkstemp(dir=wiki_concepts_dir, suffix=".md.tmp")
+
+    fd, tmp_path = tempfile.mkstemp(dir=article_path.parent, suffix=".md.tmp")
     try:
-        with open(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-        Path(tmp).replace(article_path)
+        with open(fd, "w", encoding="utf-8") as file:
+            file.write(content)
+        Path(tmp_path).replace(article_path)
     except Exception:
-        Path(tmp).unlink(missing_ok=True)
+        Path(tmp_path).unlink(missing_ok=True)
         raise
 
     log.info("wiki_article_written", slug=slug, path=str(article_path))
@@ -607,3 +1079,520 @@ def _read_wiki_article_content(
     if wiki_path.exists():
         return wiki_path.read_text(encoding="utf-8").strip()
     return ""
+
+
+# ---- Cross-page propagation (Stage 3) ----
+
+PROPAGATION_CATALOG_LIMIT = 200
+PROPAGATION_PACKET_CHARS = 4000
+
+
+@dataclass(slots=True)
+class _CatalogEntry:
+    """Existing-concept summary used to seed the propagation prompt."""
+
+    slug: str
+    title: str
+    summary: str
+    existing_connections: str
+
+
+def _build_catalog(
+    vault_path: Path,
+    folders: FolderConfig,
+    exclude_slugs: set[str],
+) -> list[_CatalogEntry]:
+    """Build the on-disk concept catalog for propagation."""
+    wiki_concepts_dir = vault_path / folders.wiki / folders.wiki_concepts
+    if not wiki_concepts_dir.exists():
+        return []
+
+    entries: list[_CatalogEntry] = []
+    for path in wiki_concepts_dir.glob("*.md"):
+        slug = path.stem.lower()
+        if slug in exclude_slugs:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            log.warning("propagation_catalog_read_failed", path=str(path), error=str(exc))
+            continue
+
+        body = _strip_frontmatter_block(text)
+        fm = _extract_frontmatter(text)
+        title = _catalog_title(fm, body, slug)
+        summary = _catalog_summary(body)
+        connections = _extract_section(body, "Connections")
+
+        entries.append(
+            _CatalogEntry(
+                slug=slug,
+                title=title,
+                summary=summary,
+                existing_connections=connections.strip(),
+            )
+        )
+
+    entries.sort(key=lambda entry: entry.slug)
+    if len(entries) > PROPAGATION_CATALOG_LIMIT:
+        log.warning("propagation_catalog_truncated", total=len(entries))
+        entries = entries[:PROPAGATION_CATALOG_LIMIT]
+    return entries
+
+
+def _strip_frontmatter_block(markdown: str) -> str:
+    """Return the markdown body without leading line-delimited frontmatter."""
+    span = _frontmatter_span(markdown)
+    if span is None:
+        return markdown
+    _content_start, _content_end, body_start = span
+    return markdown[body_start:].lstrip("\r\n")
+
+
+def _catalog_title(frontmatter: dict[str, object], body: str, slug: str) -> str:
+    """Derive a catalog title from frontmatter, body H1, or slug."""
+    title = frontmatter.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    h1 = _extract_h1_title(body)
+    if h1:
+        return h1
+    return slug.replace("-", " ").title()
+
+
+def _catalog_summary(body: str) -> str:
+    """Pull the first non-empty, non-heading paragraph as a summary."""
+    paragraph: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if paragraph:
+                break
+            continue
+        if stripped.startswith("#"):
+            if paragraph:
+                break
+            continue
+        paragraph.append(stripped)
+
+    summary = " ".join(paragraph).strip()
+    if len(summary) > 200:
+        summary = summary[:200].rstrip() + "..."
+    return summary
+
+
+def _extract_section(body: str, heading: str) -> str:
+    """Return the body of the section under `## {heading}`.
+
+    Captures everything between the heading and the next `## ` heading or EOF.
+    Returns an empty string if the section is missing.
+    """
+    pattern = re.compile(
+        rf"^##\s+{re.escape(heading)}\s*$(?P<body>.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if not match:
+        return ""
+    return match.group("body")
+
+
+def _format_catalog_block(entries: list[_CatalogEntry]) -> str:
+    """Format catalog entries for inclusion in the prompt."""
+    return "\n".join(
+        f"- {entry.slug} | {entry.title} | {entry.summary}" for entry in entries
+    )
+
+
+def _has_wikilink_to_any(text: str, slugs: set[str]) -> bool:
+    """Return True if `text` links to any slug using canonical normalization."""
+    return bool(set(extract_wikilinks(text)) & slugs)
+
+
+def _has_only_allowed_wikilinks(text: str, allowed_slugs: set[str]) -> bool:
+    """Require at least one wikilink and constrain every target to `allowed_slugs`."""
+    links = extract_wikilinks(text)
+    return bool(links) and set(links) <= allowed_slugs
+
+
+@dataclass(slots=True)
+class _PropagationTouch:
+    """A validated propagation touch ready to apply to disk."""
+
+    target_slug: str
+    connection_line: str
+    relevance: int
+    new_concept_slugs: tuple[str, ...]
+
+
+async def _propagate_to_existing_concepts(
+    *,
+    sources: list[RawSourceRecord],
+    slug_to_urls: dict[str, list[str]],
+    provider: Provider,
+    vault_path: Path,
+    folders: FolderConfig,
+    max_touches: int,
+    result: CompileResult,
+) -> None:
+    """Stage 3: cross-link new sources into existing concept pages."""
+    exclude = {slug.lower() for slug in slug_to_urls}
+    catalog = _build_catalog(vault_path, folders, exclude)
+    if not catalog:
+        return
+
+    catalog_block = _format_catalog_block(catalog)
+    catalog_by_slug = {entry.slug: entry for entry in catalog}
+    touched_slugs: set[str] = set()
+
+    # Build per-source new-concept attribution from slug_to_urls.
+    source_to_new_slugs: dict[str, list[str]] = {}
+    for slug, urls in slug_to_urls.items():
+        for url in urls:
+            source_to_new_slugs.setdefault(url, []).append(slug)
+
+    for source in sources:
+        source_key = _source_key(source)
+        new_slugs = source_to_new_slugs.get(source_key, [])
+        if not new_slugs:
+            continue
+        new_slugs_lower = {slug.lower() for slug in new_slugs}
+
+        prompt = COMPILE_GRAPH_TOUCH_PROMPT.format(
+            new_source_packet=format_raw_source_packet(source, max_chars=PROPAGATION_PACKET_CHARS),
+            new_concept_slugs=json.dumps(new_slugs),
+            catalog=catalog_block,
+        )
+
+        try:
+            response = await provider.complete(
+                prompt,
+                system="You are a precise librarian. Return only valid JSON.",
+            )
+        except Exception as exc:
+            log.error("propagation_call_failed", source=source_key, error=str(exc))
+            result.errors.append(
+                f"Propagation call for '{source_key}' failed: {exc}"
+            )
+            result.propagation_failed_sources.add(source_key)
+            continue
+
+        touches = _parse_propagation_touches(
+            response=response,
+            source_key=source_key,
+            catalog_slugs=set(catalog_by_slug.keys()),
+            new_slugs_lower=new_slugs_lower,
+            new_slugs=new_slugs,
+        )
+
+        kept = _filter_and_rank_touches(
+            touches=touches,
+            catalog_by_slug=catalog_by_slug,
+            new_slugs_lower=new_slugs_lower,
+            max_touches=max_touches,
+            vault_path=vault_path,
+            folders=folders,
+        )
+
+        for touch in kept:
+            target_path = (
+                vault_path
+                / folders.wiki
+                / folders.wiki_concepts
+                / f"{touch.target_slug}.md"
+            )
+            try:
+                _apply_touch(target_path, touch, source_key)
+            except Exception as exc:
+                log.error(
+                    "propagation_touch_failed",
+                    target=touch.target_slug,
+                    source=source_key,
+                    error=str(exc),
+                )
+                result.errors.append(
+                    f"Propagation touch on '{touch.target_slug}' from '{source_key}' failed: {exc}"
+                )
+                result.propagation_failed_sources.add(source_key)
+                continue
+            touched_slugs.add(touch.target_slug)
+            source_touches = result.propagation_touches_by_source.setdefault(source_key, [])
+            if touch.target_slug not in source_touches:
+                source_touches.append(touch.target_slug)
+
+    result.articles_touched = len(touched_slugs)
+
+
+def _parse_propagation_touches(
+    *,
+    response: str,
+    source_key: str,
+    catalog_slugs: set[str],
+    new_slugs_lower: set[str],
+    new_slugs: list[str],
+) -> list[_PropagationTouch]:
+    """Parse and per-touch-validate a propagation response."""
+    cleaned = clean_json_response(response)
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        log.warning(
+            "propagation_parse_failed",
+            source=source_key,
+            response=response[:200],
+        )
+        return []
+
+    raw_touches = data.get("touches") if isinstance(data, dict) else None
+    if not isinstance(raw_touches, list):
+        log.warning(
+            "propagation_parse_failed",
+            source=source_key,
+            response=response[:200],
+        )
+        return []
+
+    touches: list[_PropagationTouch] = []
+    for item in raw_touches:
+        if not isinstance(item, dict):
+            log.debug("propagation_touch_invalid", source=source_key, item=str(item)[:120])
+            continue
+
+        target_slug = item.get("target_slug")
+        if not isinstance(target_slug, str) or not target_slug.strip():
+            log.debug("propagation_touch_invalid_slug", source=source_key)
+            continue
+        normalized_slug = target_slug.strip().lower()
+        if normalized_slug not in catalog_slugs:
+            log.debug(
+                "propagation_touch_unknown_slug",
+                source=source_key,
+                slug=target_slug,
+            )
+            continue
+        target_slug = normalized_slug
+
+        connection_line = item.get("connection_line")
+        if not isinstance(connection_line, str) or not connection_line.strip():
+            log.debug("propagation_touch_invalid_line", source=source_key)
+            continue
+        if not _has_only_allowed_wikilinks(connection_line, new_slugs_lower):
+            log.debug(
+                "propagation_touch_unauthorized_link",
+                source=source_key,
+                slug=target_slug,
+            )
+            continue
+
+        raw_relevance = item.get("relevance", 5)
+        if isinstance(raw_relevance, int) and 1 <= raw_relevance <= 10:
+            relevance = raw_relevance
+        else:
+            relevance = 5
+
+        touches.append(
+            _PropagationTouch(
+                target_slug=target_slug,
+                connection_line=connection_line.strip(),
+                relevance=relevance,
+                new_concept_slugs=tuple(new_slugs),
+            )
+        )
+
+    return touches
+
+
+def _filter_and_rank_touches(
+    *,
+    touches: list[_PropagationTouch],
+    catalog_by_slug: dict[str, _CatalogEntry],
+    new_slugs_lower: set[str],
+    max_touches: int,
+    vault_path: Path,
+    folders: FolderConfig,
+) -> list[_PropagationTouch]:
+    """Apply current-disk idempotency, dedupe, sort, and trim."""
+    survivors: list[_PropagationTouch] = []
+    for touch in touches:
+        if touch.target_slug not in catalog_by_slug:
+            continue
+        target_path = (
+            vault_path / folders.wiki / folders.wiki_concepts / f"{touch.target_slug}.md"
+        )
+        try:
+            _frontmatter, current_body = _split_page(target_path.read_text(encoding="utf-8"))
+        except OSError:
+            # Let the write path report the durable-state failure consistently.
+            survivors.append(touch)
+            continue
+        current_connections = _extract_section(current_body, "Connections")
+        if _has_wikilink_to_any(current_connections, new_slugs_lower):
+            continue
+        survivors.append(touch)
+
+    # Dedupe by (target_slug, frozenset(new_concept_slugs)) — keep highest relevance.
+    deduped: dict[tuple[str, frozenset[str]], _PropagationTouch] = {}
+    for touch in survivors:
+        key = (touch.target_slug, frozenset(touch.new_concept_slugs))
+        existing = deduped.get(key)
+        if existing is None or touch.relevance > existing.relevance:
+            deduped[key] = touch
+
+    ordered = sorted(
+        deduped.values(),
+        key=lambda touch: (-touch.relevance, touch.target_slug),
+    )
+    return ordered[:max_touches]
+
+
+def _apply_touch(
+    target_path: Path,
+    touch: _PropagationTouch,
+    source_key: str,
+) -> None:
+    """Apply a single touch to a concept page (frontmatter + body edits)."""
+    text = target_path.read_text(encoding="utf-8")
+    frontmatter, body = _split_page(text)
+
+    new_sources = _merge_accepted_source_references(
+        _frontmatter_sources(frontmatter),
+        [source_key],
+        context=f"propagation:{target_path.stem}",
+    )
+    new_frontmatter = _frontmatter_with_sources(frontmatter, new_sources)
+    title = _single_line_title(
+        _catalog_title(frontmatter, body, target_path.stem),
+        target_path.stem.replace("-", " ").title(),
+    )
+    new_frontmatter["title"] = title
+    new_frontmatter["vaultmind"] = True
+    new_frontmatter["kind"] = "concept"
+
+    body = _append_connections_bullet(body, touch.connection_line)
+    body = _append_sources_bullet(body, source_key)
+    body = _normalize_concept_body(body, title, new_sources)
+
+    write_markdown_page(target_path, body=body, frontmatter=new_frontmatter)
+
+
+def _split_page(text: str) -> tuple[dict[str, object], str]:
+    """Split line-delimited frontmatter from a markdown page."""
+    span = _frontmatter_span(text)
+    if span is None:
+        return {}, text.lstrip("\r\n")
+    content_start, content_end, body_start = span
+
+    import yaml
+
+    try:
+        fm_data = yaml.safe_load(text[content_start:content_end])
+    except yaml.YAMLError:
+        fm_data = {}
+    frontmatter = fm_data if isinstance(fm_data, dict) else {}
+    body = text[body_start:].lstrip("\r\n")
+    return frontmatter, body
+
+
+def _frontmatter_sources(frontmatter: dict[str, object]) -> list[str]:
+    """Read existing source URLs/keys from a parsed frontmatter dict."""
+    sources = frontmatter.get("sources")
+    if isinstance(sources, list):
+        return [str(item).strip() for item in sources if item and str(item).strip()]
+    if isinstance(sources, str) and sources.strip():
+        return [sources.strip()]
+    return []
+
+
+def _frontmatter_with_sources(
+    frontmatter: dict[str, object],
+    sources: list[str],
+) -> dict[str, object]:
+    """Return a new frontmatter dict with `sources` replaced, preserving order."""
+    updated: dict[str, object] = {}
+    saw_sources = False
+    for key, value in frontmatter.items():
+        if key == "sources":
+            updated[key] = sources
+            saw_sources = True
+        else:
+            updated[key] = value
+    if not saw_sources:
+        updated["sources"] = sources
+    return updated
+
+
+def _append_connections_bullet(body: str, connection_line: str) -> str:
+    """Add a bullet to `## Connections`, creating the section if needed."""
+    bullet = f"- {connection_line}"
+    if re.search(r"^##\s+Connections\s*$", body, re.MULTILINE):
+        return _append_bullet_to_section(body, "Connections", bullet)
+
+    new_section = f"## Connections\n\n{bullet}\n"
+    return _insert_section_before(body, new_section, ["Open Questions", "Sources"])
+
+
+def _append_sources_bullet(body: str, source_key: str) -> str:
+    """Add a bullet to `## Sources`, creating the section if needed."""
+    bullet = f"- {source_key}"
+    if re.search(r"^##\s+Sources\s*$", body, re.MULTILINE):
+        section_body = _extract_section(body, "Sources")
+        if _section_has_line(section_body, bullet):
+            return body
+        return _append_bullet_to_section(body, "Sources", bullet)
+
+    new_section = f"## Sources\n\n{bullet}\n"
+    return _append_section(body, new_section)
+
+
+def _section_has_line(section_body: str, bullet: str) -> bool:
+    """Return True if `bullet` already appears as a line in `section_body`."""
+    target = bullet.strip()
+    return any(line.strip() == target for line in section_body.splitlines())
+
+
+def _append_bullet_to_section(body: str, heading: str, bullet: str) -> str:
+    """Insert `bullet` at the end of `## {heading}` (before next `## ` or EOF)."""
+    pattern = re.compile(
+        rf"(^##\s+{re.escape(heading)}\s*$)(?P<body>.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+
+    def replace(match: re.Match[str]) -> str:
+        heading_line = match.group(1)
+        section_body = match.group("body")
+        # Strip trailing whitespace/newlines, append bullet, restore spacing.
+        trimmed = section_body.rstrip("\n")
+        new_body = (
+            f"{trimmed}\n{bullet}\n\n" if trimmed.strip() else f"\n{bullet}\n\n"
+        )
+        return heading_line + new_body
+
+    return pattern.sub(replace, body, count=1)
+
+
+def _insert_section_before(
+    body: str,
+    new_section: str,
+    preferred_headings: list[str],
+) -> str:
+    """Insert `new_section` immediately before the first matching heading.
+
+    Falls back to appending at the end if none of the headings appear.
+    """
+    sections = _markdown_h2_sections(body)
+    for heading in preferred_headings:
+        match = next((section for section in sections if section.title == heading), None)
+        if match is None:
+            continue
+        prefix = body[:match.start].rstrip("\n")
+        suffix = body[match.start:]
+        return f"{prefix}\n\n{new_section}\n{suffix}"
+    return _append_section(body, new_section)
+
+
+def _append_section(body: str, new_section: str) -> str:
+    """Append `new_section` to the end of the body with consistent spacing."""
+    trimmed = body.rstrip("\n")
+    if trimmed:
+        return f"{trimmed}\n\n{new_section}"
+    return new_section

--- a/src/vaultmind/ai/prompts.py
+++ b/src/vaultmind/ai/prompts.py
@@ -4,26 +4,26 @@ from __future__ import annotations
 
 # ---- vm ask prompts ----
 
-ASK_SYSTEM_PROMPT = """You are VaultMind's query synthesis engine. You answer questions by synthesizing information from the provided wiki articles and raw sources. You must ground every claim in the input materials. Never invent facts, URLs, or conclusions not supported by the sources."""
+ASK_SYSTEM_PROMPT = """You are VaultMind's iterative query synthesis engine. You answer questions by synthesizing only the provided concept pages, previously filed query answers, and Raw sources. Ground every claim in those materials. Never invent facts, URLs, or conclusions. When later context adds evidence, regenerate a complete answer rather than appending an ungrounded correction."""
 
-ASK_USER_PROMPT = """Answer the question below using only the provided wiki articles and raw sources. If the materials do not contain enough information to fully answer the question, say so clearly and identify what additional knowledge would be needed.
+ASK_USER_PROMPT = """Synthesize the best complete answer to the question using only the accumulated context below. The context may include concept pages, previously filed query answers, and Raw sources found during earlier gap searches. If it is insufficient, state the limitation in the answer. Do not create markdown headings.
 
 Return ONLY valid JSON in this exact shape:
-{{"answer": "your comprehensive answer in paragraph form", "gaps": ["what's still unknown or would need follow-up research"]}}
+{{"answer": "your grounded, comprehensive answer in paragraph form"}}
 
 Question: {question}
 
-Context:
+Accumulated context:
 {context}
 """
 
-ASK_SELF_ASSESS_PROMPT = """Given your answer and the question, identify knowledge gaps — areas where the provided sources do not fully address what is being asked. Return only the gaps.
+ASK_SELF_ASSESS_PROMPT = """Assess the latest answer against the original question. Identify only concrete, searchable knowledge gaps that prevent a complete, source-grounded answer. Return an empty list when the latest answer fully addresses the question. Do not repeat gaps that the answer resolved.
 
-Return JSON:
-{{"gaps": ["gap description 1", "gap description 2"]}}
+Return ONLY valid JSON in this exact shape:
+{{"gaps": ["concise searchable gap description"]}}
 
-Question: {question}
-Answer: {answer}
+Original question: {question}
+Latest answer: {answer}
 """
 
 

--- a/src/vaultmind/ai/prompts.py
+++ b/src/vaultmind/ai/prompts.py
@@ -58,39 +58,46 @@ Sources:
 """
 
 
-COMPILE_ARTICLE_CREATE_PROMPT = """Write a new wiki article for the concept "{concept_name}".
+COMPILE_ARTICLE_CREATE_PROMPT = """Write a new, source-grounded wiki article for the concept "{concept_name}".
 
 Description: {description}
-Sources to synthesize: {source_urls}
 
-The article should:
+Attributed citations and bounded Raw source packets:
+{source_context}
+
+Contract and rules:
+- Base factual content only on the supplied Raw packets; mark uncertainty when a cited source is unavailable
 - Be 400-800 words
-- Have clear sections: Overview, Key Ideas, Sources
-- Include a Sources section with full URLs, listed in order of importance
+- Begin with exactly one `# {concept_name}` H1
+- Include every section exactly as an H2: Overview, Key Ideas, Connections, Open Questions, Sources
+- List every attributed source citation once as a bullet under Sources, including unresolved source keys
 - Be written in an encyclopedic but accessible tone
-- Use wikilinks for related concepts you know about (e.g. [[attention-mechanisms]])
+- Use Obsidian wikilinks for related concepts where appropriate (e.g. [[attention-mechanisms]])
 - Do NOT repeat exact quotes from sources — synthesize in your own words
 
 Write the article in full markdown. No frontmatter. No code blocks unless showing code.
 """
 
 
-COMPILE_ARTICLE_UPDATE_PROMPT = """You are maintaining a research wiki. Update the existing wiki article to incorporate new information from the listed sources.
+COMPILE_ARTICLE_UPDATE_PROMPT = """You are maintaining a research wiki. Update the existing article using the bounded Raw source packets below.
 
-Existing article:
+Existing article (possibly truncated by the caller):
 ---
 {existing_content}
 ---
 
-New sources to incorporate:
+Attributed citations and new Raw source packets:
 {new_sources}
 
-Rules:
-- Update the article to incorporate all new information
+Contract and rules:
+- Base new factual content only on the supplied Raw packets; mark uncertainty when a cited source is unavailable
+- Preserve useful existing content while incorporating all relevant new information
+- Begin with exactly one H1 matching the existing human title
+- Include every section exactly as an H2: Overview, Key Ideas, Connections, Open Questions, Sources
+- List every attributed source citation once as a bullet under Sources, including unresolved source keys
 - Maintain consistent structure and tone with the existing article
-- Add new backlinks to related concepts where appropriate (e.g. [[attention-mechanisms]])
+- Add Obsidian wikilinks to related concepts where appropriate (e.g. [[attention-mechanisms]])
 - Be 400-800 words unless the new sources substantially expand the topic
-- Keep the Sources section updated — add new URLs at the bottom
 - Do NOT repeat exact quotes — synthesize in your own words
 
 Write the updated article in full markdown. No frontmatter.
@@ -116,6 +123,37 @@ Rules:
 
 Write the updated index in full markdown. No frontmatter.
 """
+
+COMPILE_GRAPH_TOUCH_PROMPT = """You are maintaining a research wiki. A NEW source has been ingested and contributed to the following NEW concept pages. Identify EXISTING concept pages whose `## Connections` section should cross-link to one of the new concepts.
+
+You will be given:
+- The NEW source body (title, source URL/key, tags, then the original article text).
+- The list of NEW concept slugs that this source contributed to.
+- A catalog of EXISTING concept pages, one per line, formatted as:
+  `<slug> | <title> | <one-line summary>`
+
+Rules:
+- Only choose `target_slug` values that appear EXACTLY in the catalog. Do not invent slugs.
+- Each `connection_line` MUST be a SINGLE short sentence describing the relationship.
+- Each `connection_line` MUST include at least one Obsidian wikilink to one of the NEW concept slugs in the form `[[<new-slug>|<Title>]]`. Use the exact new-slug; the title can be human-readable.
+- Do NOT include wikilinks to slugs other than the NEW concept slugs provided.
+- `relevance` is an integer 1-10. Use 10 only for direct, central connections; use 1-3 for distant or speculative ones. If unsure, use 5.
+- Be conservative — only propose a touch if the existing concept page would genuinely benefit from the cross-link. Prefer fewer, stronger connections over many weak ones.
+- Cap your response at 10 entries. The caller may further trim.
+- If no good connections exist, return `{{"touches": []}}`.
+
+Respond ONLY with valid JSON in this exact shape:
+{{"touches": [{{"target_slug": "...", "connection_line": "...", "relevance": 1-10}}]}}
+
+NEW concept slugs: {new_concept_slugs}
+
+NEW source:
+{new_source_packet}
+
+EXISTING concept catalog (slug | title | summary):
+{catalog}
+"""
+
 
 COMPILE_CONCEPT_DEDUP_PROMPT = """You are a librarian deduplicating a concept list. Given a list of concepts identified from raw sources, merge overlapping or near-duplicate concepts into a single canonical entry.
 

--- a/src/vaultmind/commands/ask.py
+++ b/src/vaultmind/commands/ask.py
@@ -27,7 +27,8 @@ def ask(
 
     Use --preview to print the answer without filing it.
     """
-    setup_logging(verbose=verbose)
+    if not preview:
+        setup_logging(verbose=verbose)
     config = load_config()
 
     if depth not in ("shallow", "deep"):

--- a/src/vaultmind/commands/compile.py
+++ b/src/vaultmind/commands/compile.py
@@ -32,7 +32,7 @@ from vaultmind.core.manifest import (
 from vaultmind.core.raw_scanner import RawSourceRecord, scan_raw_sources
 from vaultmind.core.wiki_log import append_wiki_log
 from vaultmind.core.writer import write_markdown_page
-from vaultmind.schemas import Manifest
+from vaultmind.schemas import Manifest, ManifestSource
 from vaultmind.utils.display import print_info, print_success, print_warning
 from vaultmind.utils.hashing import content_hash
 from vaultmind.utils.logging import setup_logging
@@ -40,10 +40,26 @@ from vaultmind.utils.logging import setup_logging
 log = structlog.get_logger()
 
 
+def _validate_max_touches(value: int) -> int:
+    """Reject negative --max-touches values at the Typer parse layer."""
+    if value < 0:
+        raise typer.BadParameter("--max-touches must be >= 0")
+    return value
+
+
 def compile(
     full: bool = typer.Option(False, "--full", help="Full rebuild — skip manifest diff"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would change without writing"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Debug logging"),
+    max_touches: int = typer.Option(
+        5,
+        "--max-touches",
+        help=(
+            "Max existing concept pages each source may touch in its "
+            "Connections section. 0 disables propagation."
+        ),
+        callback=_validate_max_touches,
+    ),
 ) -> None:
     """Compile source notes into wiki concept articles.
 
@@ -99,7 +115,14 @@ def compile(
     provider = get_provider(config, tier="deep")
 
     result, slug_to_urls = asyncio.run(
-        _run_compile_async(sources_to_compile, manifest, config, provider, dry_run)
+        _run_compile_async(
+            sources_to_compile,
+            manifest,
+            config,
+            provider,
+            dry_run,
+            max_touches=max_touches,
+        )
     )
 
     if dry_run:
@@ -113,12 +136,19 @@ def compile(
     if result.articles_created > 0 or result.articles_updated > 0:
         _rebuild_wiki_index(config, manifest, provider)
 
-    # Print success unless we're in full-failure case (no creations, no updates, but errors exist)
-    if not (result.articles_created == 0 and result.articles_updated == 0 and result.errors):
+    # Print success unless we're in the full-failure case
+    # (no creations, no updates, no touches, but errors exist).
+    if not (
+        result.articles_created == 0
+        and result.articles_updated == 0
+        and result.articles_touched == 0
+        and result.errors
+    ):
         print_success(
             "Compile complete",
             f"{result.articles_created} created, "
             f"{result.articles_updated} updated, "
+            f"{result.articles_touched} touched, "
             f"{result.sources_compiled} sources processed."
         )
 
@@ -135,6 +165,8 @@ async def _run_compile_async(
     config: AppConfig,
     provider: Provider,
     dry_run: bool,
+    *,
+    max_touches: int = 5,
 ) -> tuple[CompileResult, dict[str, list[str]]]:
     result, slug_to_urls = await compile_sources(
         sources,
@@ -144,25 +176,47 @@ async def _run_compile_async(
         config.folders,
         dry_run=dry_run,
         existing_concepts=_existing_concept_summaries(config),
+        max_touches=max_touches,
     )
 
-    if not dry_run and (result.articles_created > 0 or result.articles_updated > 0):
-        # slug_to_urls maps slug → source_urls
-        # For raw sources, manifest keys are source_url (preferred) or relative_path
+    if not dry_run and (
+        result.articles_created > 0
+        or result.articles_updated > 0
+        or result.articles_touched > 0
+    ):
+        # Reconcile article provenance in both directions. A propagation failure
+        # may happen after article writes, so retain its previous hash (or a
+        # non-current placeholder for a new source) to make incremental retry
+        # deterministic while still recording any durable article references.
         source_key_to_source = {s.source_url or s.relative_path: s for s in sources}
-
+        source_to_articles: dict[str, list[str]] = {}
         for slug, urls in slug_to_urls.items():
-            for url in urls:
-                source = source_key_to_source.get(url)
-                if source is None:
-                    continue
-                upsert_source(
+            for source_key in urls:
+                articles = source_to_articles.setdefault(source_key, [])
+                if slug not in articles:
+                    articles.append(slug)
+        for source_key, touched_slugs in result.propagation_touches_by_source.items():
+            articles = source_to_articles.setdefault(source_key, [])
+            articles.extend(slug for slug in touched_slugs if slug not in articles)
+
+        for source_key, articles in source_to_articles.items():
+            source = source_key_to_source.get(source_key)
+            if source is None:
+                continue
+            if source_key in result.propagation_failed_sources:
+                _merge_failed_source_provenance(
                     manifest,
-                    url=url,
-                    content_hash=source.content_hash,
-                    saved_at=datetime.now(UTC),
-                    wiki_articles=[slug],
+                    source_key=source_key,
+                    wiki_articles=articles,
                 )
+                continue
+            upsert_source(
+                manifest,
+                url=source_key,
+                content_hash=source.content_hash,
+                saved_at=datetime.now(UTC),
+                wiki_articles=articles,
+            )
 
         # Rebuild manifest wiki_articles from disk (scan wiki concepts directory)
         wiki_concepts_dir = config.vault_path / config.folders.wiki / config.folders.wiki_concepts
@@ -201,6 +255,29 @@ async def _run_compile_async(
         )
 
     return result, slug_to_urls
+
+
+def _merge_failed_source_provenance(
+    manifest: Manifest,
+    *,
+    source_key: str,
+    wiki_articles: list[str],
+) -> None:
+    """Record durable backlinks without marking a failed source current."""
+    existing = manifest.sources.get(source_key)
+    if existing is not None:
+        merged_articles = list(dict.fromkeys([*existing.wiki_articles, *wiki_articles]))
+        manifest.sources[source_key] = existing.model_copy(
+            update={"wiki_articles": merged_articles}
+        )
+        return
+
+    manifest.sources[source_key] = ManifestSource(
+        content_hash="",
+        saved_at=datetime.now(UTC),
+        compiled_at=None,
+        wiki_articles=list(dict.fromkeys(wiki_articles)),
+    )
 
 
 def _extract_article_sources(article_path: Path) -> list[str]:
@@ -314,6 +391,8 @@ def _render_dry_run_summary(
         lines.append(f"  → {slug}")
         for url in urls:
             lines.append(f"     - {url}")
+
+    lines.extend(["", "Propagation: deferred in dry-run."])
 
     return "\n".join(lines)
 

--- a/tests/test_asker.py
+++ b/tests/test_asker.py
@@ -6,6 +6,8 @@ import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from vaultmind.ai.asker import (
     AskResult,
     GatheredContext,
@@ -134,7 +136,7 @@ class TestRenderAnswerMarkdown:
             now=datetime.now(UTC),
         )
         assert "# What is attention?" in body
-        assert "## 💡 Answer" in body
+        assert "## Answer" in body
         assert "It is a mechanism." in body
 
     def test_supporting_notes_section(self):
@@ -146,7 +148,7 @@ class TestRenderAnswerMarkdown:
             iterations=1,
             now=datetime.now(UTC),
         )
-        assert "## Supporting Notes" in body
+        assert "## Supporting Wiki Pages" in body
         assert "[[path/to/note1]]" in body
         assert "[[path/to/note2]]" in body
 
@@ -159,7 +161,7 @@ class TestRenderAnswerMarkdown:
             iterations=1,
             now=datetime.now(UTC),
         )
-        assert "## Supporting Sources" in body
+        assert "## Supporting Raw Sources" in body
         assert "https://example.com/article" in body
 
     def test_iterations_in_footer(self):
@@ -200,6 +202,49 @@ class TestFollowUpGap:
         # Gap found a note with same title "Attention" — deduplication prevents adding a second
         titles = [n.title for n in ctx.wiki_notes]
         assert titles.count("Attention") == 1
+
+    def test_searches_raw_when_only_strong_wiki_match_is_already_gathered(
+        self, tmp_path: Path
+    ):
+        vault = tmp_path / "vault"
+        wiki_dir = vault / "Wiki" / "Concepts"
+        raw_dir = vault / "Raw"
+        wiki_dir.mkdir(parents=True)
+        raw_dir.mkdir(parents=True)
+        (wiki_dir / "capacity.md").write_text(
+            "---\ntitle: Capacity\nvaultmind: true\n---\n\n# Capacity\n\nCapacity overview.",
+            encoding="utf-8",
+        )
+        (raw_dir / "capacity-details.md").write_text(
+            "# Capacity details\n\nCapacity evidence missing from the overview.", encoding="utf-8"
+        )
+        context = _initial_search("capacity", vault, "Wiki", "Concepts", "Raw", "Queries")
+        assert [note.title for note in context.wiki_notes] == ["Capacity"]
+        assert context.raw_sources == []
+
+        _follow_up_gap("capacity", context, vault, "Wiki", "Concepts", "Raw", "Queries")
+
+        assert [source.title for source in context.raw_sources] == ["Capacity details"]
+
+    def test_new_strong_wiki_match_skips_raw(self, tmp_path: Path):
+        vault = tmp_path / "vault"
+        wiki_dir = vault / "Wiki" / "Concepts"
+        raw_dir = vault / "Raw"
+        wiki_dir.mkdir(parents=True)
+        raw_dir.mkdir(parents=True)
+        (wiki_dir / "capacity.md").write_text(
+            "---\ntitle: Capacity\nvaultmind: true\n---\n\n# Capacity\n\nCapacity overview.",
+            encoding="utf-8",
+        )
+        (raw_dir / "capacity.md").write_text(
+            "# Capacity raw\n\nCapacity source evidence.", encoding="utf-8"
+        )
+        context = GatheredContext()
+
+        _follow_up_gap("capacity", context, vault, "Wiki", "Concepts", "Raw", "Queries")
+
+        assert [note.title for note in context.wiki_notes] == ["Capacity"]
+        assert context.raw_sources == []
 
 
 class TestInitialSearch:
@@ -246,6 +291,27 @@ class TestInitialSearch:
         assert [note.title for note in ctx.wiki_notes] == ["RLHF"]
         assert ctx.raw_sources == []
 
+    def test_searches_filed_queries_and_uses_combined_wiki_strength(self, tmp_path: Path):
+        vault = tmp_path / "vault"
+        query_dir = vault / "🗺️ Wiki" / "📊 Queries"
+        raw_dir = vault / "📥 Raw"
+        query_dir.mkdir(parents=True)
+        raw_dir.mkdir(parents=True)
+        (query_dir / "dpo.md").write_text(
+            "---\ntitle: DPO\nvaultmind: true\nkind: query\ncreated: 2026-01-01T00:00:00+00:00\n---\n\n"
+            "# DPO\n\n## Answer\nDPO directly optimizes preferences.",
+            encoding="utf-8",
+        )
+        (raw_dir / "dpo.md").write_text("# DPO raw\n\nDPO source.", encoding="utf-8")
+
+        ctx = _initial_search(
+            "DPO", vault, "🗺️ Wiki", "🧠 Concepts", "📥 Raw", "📊 Queries"
+        )
+
+        assert [note.source_type for note in ctx.wiki_notes] == ["query"]
+        assert ctx.wiki_notes[0].relative_path == "🗺️ Wiki/📊 Queries/dpo"
+        assert ctx.raw_sources == []
+
 
 class TestAskResult:
     def test_ask_result_dataclass(self):
@@ -286,7 +352,308 @@ def test_ask_preview_does_not_write_query_file(tmp_path: Path):
 
     assert result.answer == "RLHF uses human feedback."
     assert not result.path.exists()
+    assert not (vault / "🗺️ Wiki").exists()
+    assert not (vault / "vault.manifest.json").exists()
     assert "RLHF uses human feedback" in provider.prompts[0]
+
+
+def test_deep_ask_runs_three_syntheses_and_returns_latest_gaps(tmp_path: Path):
+    vault = tmp_path / "vault"
+    raw_dir = vault / "📥 Raw"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "alpha.md").write_text("# Alpha\n\nalpha evidence", encoding="utf-8")
+    (raw_dir / "beta.md").write_text("# Beta\n\nbeta evidence", encoding="utf-8")
+    provider = StubProvider([
+        '{"answer": "first"}',
+        '{"gaps": ["alpha evidence"]}',
+        '{"answer": "second"}',
+        '{"gaps": ["beta evidence"]}',
+        '{"answer": "third"}',
+        '{"gaps": ["fresh final gap"]}',
+    ])
+
+    result = asyncio.run(ask_question(
+        "Uncovered topic",
+        provider,
+        vault,
+        "🗺️ Wiki",
+        "🧠 Concepts",
+        "📊 Queries",
+        "📥 Raw",
+        depth="deep",
+        file_answer=False,
+    ))
+
+    assert result.answer == "third"
+    assert result.iterations == 3
+    assert result.gaps == ["fresh final gap"]
+    assert len(provider.prompts) == 6
+    assert "alpha evidence" in provider.prompts[2]
+    assert "alpha evidence" in provider.prompts[4]
+    assert "beta evidence" in provider.prompts[4]
+
+
+def test_deep_ask_stops_after_latest_assessment_reports_no_gaps(tmp_path: Path):
+    provider = StubProvider(['{"answer": "complete"}', '{"gaps": []}'])
+
+    result = asyncio.run(ask_question(
+        "Question",
+        provider,
+        tmp_path,
+        "Wiki",
+        "Concepts",
+        "Queries",
+        "Raw",
+        depth="deep",
+        file_answer=False,
+    ))
+
+    assert result.iterations == 1
+    assert result.gaps == []
+    assert len(provider.prompts) == 2
+
+
+def test_follow_up_context_is_deduplicated_and_capped(tmp_path: Path):
+    vault = tmp_path / "vault"
+    concepts = vault / "Wiki" / "Concepts"
+    raw = vault / "Raw"
+    concepts.mkdir(parents=True)
+    raw.mkdir(parents=True)
+    for index in range(35):
+        (concepts / f"note-{index}.md").write_text(
+            f"---\ntitle: Note {index}\nvaultmind: true\nkind: concept\n---\n\n"
+            f"# Note {index}\n\ncapacity evidence {index}",
+            encoding="utf-8",
+        )
+    for index in range(25):
+        (raw / f"source-{index}.md").write_text(
+            f"# Source {index}\n\ncapacity raw evidence {index}", encoding="utf-8"
+        )
+
+    context = GatheredContext()
+    _follow_up_gap("capacity", context, vault, "Wiki", "Concepts", "Raw", "Queries")
+    _follow_up_gap("capacity", context, vault, "Wiki", "Concepts", "Raw", "Queries")
+
+    assert len(context.wiki_notes) == 30
+    assert len(context.raw_sources) == 20
+    assert len({note.relative_path for note in context.wiki_notes}) == 30
+    assert len({source.relative_path for source in context.raw_sources}) == 20
+
+
+def test_query_page_contract_and_final_gap_rendering():
+    body = _render_answer_markdown(
+        "Question?",
+        "# Unsafe provider heading\n\nAnswer.",
+        supporting_notes=["Wiki/Concepts/one", "Wiki/Queries/two"],
+        supporting_sources=["Raw/source"],
+        iterations=3,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+        gaps=["First gap", "Second gap"],
+    )
+
+    assert [line for line in body.splitlines() if line.startswith("# ")] == ["# Question?"]
+    assert [line for line in body.splitlines() if line.startswith("## ")] == [
+        "## Answer",
+        "## Supporting Wiki Pages",
+        "## Supporting Raw Sources",
+        "## Follow-up Questions",
+    ]
+    assert "- [[Wiki/Concepts/one]]" in body
+    assert "- [[Wiki/Queries/two]]" in body
+    assert "- First gap\n- Second gap" in body
+
+
+def test_query_page_sanitizes_setext_headings_but_preserves_fenced_examples():
+    answer = """Provider title
+==============
+
+Answer text.
+
+Provider section
+----------------
+
+```markdown
+Fenced title
+============
+# Fenced ATX title
+```
+
+~~~markdown
+Fenced section
+--------------
+## Fenced ATX section
+~~~"""
+
+    body = _render_answer_markdown(
+        "Question?",
+        answer,
+        supporting_notes=[],
+        supporting_sources=[],
+        iterations=1,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    assert "### Provider title" in body
+    assert "### Provider section" in body
+    assert "Provider title\n==============" not in body
+    assert "Provider section\n----------------" not in body
+    assert "Fenced title\n============\n# Fenced ATX title" in body
+    assert "Fenced section\n--------------\n## Fenced ATX section" in body
+    assert "Answer text." in body
+
+
+def test_query_page_fences_follow_commonmark_marker_and_closer_rules():
+    answer = """~~~`markdown`
+# Keep in tilde fence with backtick info
+~~~
+~~~ `markdown`
+## Keep in tilde fence with spaced backtick info
+~~~
+# Demote after tilde fence
+
+````markdown
+# Keep before shorter pseudo-closer
+```
+# Keep after shorter pseudo-closer
+~~~~
+# Keep after mismatched marker
+````
+# Demote after backtick fence
+
+~~~markdown
+# Keep before trailing-content pseudo-closer
+~~~ not-a-closer
+## Keep after trailing-content pseudo-closer
+~~~
+## Demote after final fence
+
+```markdown `invalid-info`
+# Demote after invalid backtick opener"""
+
+    body = _render_answer_markdown(
+        "Question?",
+        answer,
+        supporting_notes=[],
+        supporting_sources=[],
+        iterations=1,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    assert "# Keep in tilde fence with backtick info" in body
+    assert "## Keep in tilde fence with spaced backtick info" in body
+    assert "### Demote after tilde fence" in body
+    assert "# Keep after shorter pseudo-closer" in body
+    assert "# Keep after mismatched marker" in body
+    assert "### Demote after backtick fence" in body
+    assert "## Keep after trailing-content pseudo-closer" in body
+    assert "### Demote after final fence" in body
+    assert "### Demote after invalid backtick opener" in body
+
+
+def test_query_page_uses_explicit_no_gaps_marker():
+    body = _render_answer_markdown(
+        "Question?",
+        "Answer.",
+        supporting_notes=[],
+        supporting_sources=[],
+        iterations=1,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+        gaps=[],
+    )
+    assert "## Follow-up Questions\n*No follow-up questions.*" in body
+
+
+def test_filed_answer_is_reused_by_a_later_question(tmp_path: Path):
+    vault = tmp_path / "vault"
+    first_provider = StubProvider(['{"answer": "RLHF alignment uses preference feedback."}'])
+    first = asyncio.run(ask_question(
+        "How does RLHF improve alignment?",
+        first_provider,
+        vault,
+        "Wiki",
+        "Concepts",
+        "Queries",
+        "Raw",
+        depth="shallow",
+    ))
+    second_provider = StubProvider(['{"answer": "It reuses filed knowledge."}'])
+
+    second = asyncio.run(ask_question(
+        "RLHF alignment",
+        second_provider,
+        vault,
+        "Wiki",
+        "Concepts",
+        "Queries",
+        "Raw",
+        depth="shallow",
+    ))
+
+    assert "RLHF alignment uses preference feedback." in second_provider.prompts[0]
+    second_text = second.path.read_text(encoding="utf-8")
+    assert f"[[Wiki/Queries/{first.slug}]]" in second_text
+
+
+@pytest.mark.parametrize("question", ["", "   ", "First line\nSecond line", "First\rSecond"])
+def test_ask_rejects_questions_that_cannot_be_an_exact_h1(
+    tmp_path: Path,
+    question: str,
+):
+    provider = StubProvider(['{"answer": "must not run"}'])
+
+    with pytest.raises(ValueError):
+        asyncio.run(
+            ask_question(
+                question,
+                provider,
+                tmp_path / "vault",
+                "Wiki",
+                "Concepts",
+                "Queries",
+                "Raw",
+                depth="shallow",
+            )
+        )
+
+    assert provider.prompts == []
+    assert not (tmp_path / "vault").exists()
+
+
+def test_repeated_query_refresh_excludes_its_own_page_from_support(tmp_path: Path):
+    vault = tmp_path / "vault"
+    first_provider = StubProvider(['{"answer": "Original evidence."}'])
+    first = asyncio.run(
+        ask_question(
+            "What is RLHF?",
+            first_provider,
+            vault,
+            "Wiki",
+            "Concepts",
+            "Queries",
+            "Raw",
+            depth="shallow",
+        )
+    )
+    first_relative_path = f"Wiki/Queries/{first.slug}"
+
+    refresh_provider = StubProvider(['{"answer": "Refreshed answer."}'])
+    refreshed = asyncio.run(
+        ask_question(
+            "What is RLHF?",
+            refresh_provider,
+            vault,
+            "Wiki",
+            "Concepts",
+            "Queries",
+            "Raw",
+            depth="shallow",
+        )
+    )
+
+    assert "Original evidence." not in refresh_provider.prompts[0]
+    refreshed_text = refreshed.path.read_text(encoding="utf-8")
+    assert f"[[{first_relative_path}]]" not in refreshed_text
+    assert "Refreshed answer." in refreshed_text
 
 
 def test_ask_files_query_when_enabled(tmp_path: Path):

--- a/tests/test_commands/test_ask.py
+++ b/tests/test_commands/test_ask.py
@@ -1,0 +1,45 @@
+"""Tests for vm ask command behavior."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from vaultmind.ai.asker import AskResult
+from vaultmind.commands import ask as ask_cmd
+from vaultmind.main import app
+
+
+def test_ask_preview_is_strictly_no_write(monkeypatch, test_config):
+    """CLI preview skips file logging, query filing, and wiki-log appends."""
+    query_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_queries
+    wiki_log = test_config.vault_path / test_config.folders.wiki / "📋 Log.md"
+    wiki_log.parent.mkdir(parents=True, exist_ok=True)
+    wiki_log.write_text("# Wiki Log\n\nExisting entry.\n", encoding="utf-8")
+    original_log = wiki_log.read_text(encoding="utf-8")
+
+    def fail_setup_logging(*, verbose: bool = False) -> None:
+        raise AssertionError(f"filesystem-writing logging setup called (verbose={verbose})")
+
+    async def fake_ask_question(**kwargs):
+        assert kwargs["file_answer"] is False
+        path = query_dir / "preview-question.md"
+        return AskResult(
+            answer="Preview answer.",
+            slug="preview-question",
+            path=path,
+            iterations=1,
+            gaps=[],
+        )
+
+    monkeypatch.setattr(ask_cmd, "setup_logging", fail_setup_logging)
+    monkeypatch.setattr(ask_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(ask_cmd, "get_provider", lambda config, tier: object())
+    monkeypatch.setattr(ask_cmd, "ask_question", fake_ask_question)
+
+    result = CliRunner().invoke(app, ["ask", "Preview question?", "--preview"])
+
+    assert result.exit_code == 0, result.output
+    assert "Preview answer." in result.output
+    assert not query_dir.exists()
+    assert not (query_dir / "preview-question.md").exists()
+    assert wiki_log.read_text(encoding="utf-8") == original_log

--- a/tests/test_commands/test_compile.py
+++ b/tests/test_commands/test_compile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
@@ -47,7 +48,7 @@ def test_compile_incremental_includes_relative_path_only_sources(monkeypatch, te
     monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
     monkeypatch.setattr(compile_cmd, "print_warning", lambda message: None)
 
-    async def fake_run(sources, manifest, config, provider, dry_run):
+    async def fake_run(sources, manifest, config, provider, dry_run, **kwargs):
         called["run_called"] = True
         called["sources"] = sources
         return (
@@ -86,8 +87,9 @@ def test_run_compile_async_upserts_manifest_with_relative_path_key(monkeypatch, 
         *,
         dry_run=False,
         existing_concepts=None,
+        max_touches=5,
     ):
-        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts
+        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts, max_touches
         return (
             compile_cmd.CompileResult(
                 articles_created=1,
@@ -133,8 +135,9 @@ def test_run_compile_async_merges_one_source_into_multiple_concepts(monkeypatch,
         *,
         dry_run=False,
         existing_concepts=None,
+        max_touches=5,
     ):
-        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts
+        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts, max_touches
         return (
             compile_cmd.CompileResult(
                 articles_created=2,
@@ -182,8 +185,9 @@ def test_run_compile_async_writes_manifest_and_compile_log(monkeypatch, test_con
         *,
         dry_run=False,
         existing_concepts=None,
+        max_touches=5,
     ):
-        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts
+        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts, max_touches
         return (
             compile_cmd.CompileResult(
                 articles_created=1,
@@ -253,8 +257,9 @@ def test_run_compile_async_preserves_article_frontmatter_sources_in_manifest(
         *,
         dry_run=False,
         existing_concepts=None,
+        max_touches=5,
     ):
-        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts
+        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts, max_touches
         return (
             compile_cmd.CompileResult(
                 articles_created=0,
@@ -319,7 +324,7 @@ def test_compile_dry_run_writes_no_state_files(monkeypatch, test_config):
     monkeypatch.setattr(compile_cmd, "print_warning", lambda message: None)
     monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
 
-    async def fake_run(sources, manifest, config, provider, dry_run):
+    async def fake_run(sources, manifest, config, provider, dry_run, **kwargs):
         assert dry_run is True
         return (
             compile_cmd.CompileResult(
@@ -417,7 +422,7 @@ def test_compile_exits_nonzero_when_errors_present(monkeypatch, test_config):
 
     monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
 
-    async def fake_run(sources, manifest, config, provider, dry_run):
+    async def fake_run(sources, manifest, config, provider, dry_run, **kwargs):
         return (
             compile_cmd.CompileResult(
                 articles_created=0,
@@ -464,7 +469,7 @@ def test_compile_prints_each_error_with_concept_name(monkeypatch, test_config):
 
     monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
 
-    async def fake_run(sources, manifest, config, provider, dry_run):
+    async def fake_run(sources, manifest, config, provider, dry_run, **kwargs):
         return (
             compile_cmd.CompileResult(
                 articles_created=0,
@@ -519,7 +524,7 @@ def test_compile_no_extra_warning_when_no_errors(monkeypatch, test_config):
     monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
     monkeypatch.setattr(compile_cmd, "print_success", capture_success)
 
-    async def fake_run(sources, manifest, config, provider, dry_run):
+    async def fake_run(sources, manifest, config, provider, dry_run, **kwargs):
         return (
             compile_cmd.CompileResult(
                 articles_created=1,
@@ -548,6 +553,173 @@ def test_compile_no_extra_warning_when_no_errors(monkeypatch, test_config):
     assert success_printed[0][0] == "Compile complete"
 
 
+# ---- --max-touches plumbing ----
+
+
+def test_run_compile_async_threads_max_touches_into_compile_sources(monkeypatch, test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    captured: dict[str, object] = {}
+
+    async def fake_compile_sources(
+        sources,
+        manifest_arg,
+        provider,
+        vault_path,
+        folders,
+        *,
+        dry_run=False,
+        existing_concepts=None,
+        max_touches=5,
+    ):
+        del manifest_arg, provider, vault_path, folders, dry_run, existing_concepts
+        captured["max_touches"] = max_touches
+        return (
+            compile_cmd.CompileResult(
+                articles_created=0,
+                articles_updated=0,
+                sources_compiled=len(sources),
+                errors=[],
+            ),
+            {},
+        )
+
+    monkeypatch.setattr(compile_cmd, "compile_sources", fake_compile_sources)
+
+    asyncio.run(
+        compile_cmd._run_compile_async(
+            [source],
+            Manifest(),
+            test_config,
+            provider=object(),
+            dry_run=True,
+            max_touches=7,
+        )
+    )
+
+    assert captured["max_touches"] == 7
+
+
+def test_run_compile_async_propagation_touches_land_in_manifest(monkeypatch, test_config):
+    """Touched concept pages should appear in manifest.wiki_articles[target].source_urls
+    via the existing disk-scanning manifest-rebuild loop — no extra code path."""
+    import json
+
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    concepts_dir = (
+        test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    )
+    concepts_dir.mkdir(parents=True, exist_ok=True)
+    target_path = concepts_dir / "existing-target.md"
+    target_path.write_text(
+        "\n".join(
+            [
+                "---",
+                'title: "Existing Target"',
+                "vaultmind: true",
+                "kind: concept",
+                "sources:",
+                "  - https://example.com/legacy",
+                "---",
+                "",
+                "# Existing Target",
+                "",
+                "## Overview",
+                "",
+                "Some body.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    # Real StubProvider with three responses: triage, article create, touch.
+    class StubProvider:
+        def __init__(self, responses):
+            self.responses = responses
+            self.model = "stub"
+
+        async def complete(self, prompt: str, system: str = "") -> str:
+            del system, prompt
+            return self.responses.pop(0)
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "New Concept",
+                    "status": "new",
+                    "description": "A new concept",
+                    "source_urls": [source.source_url],
+                    "merge_target": None,
+                }
+            ]
+        }
+    )
+    touch = json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": "existing-target",
+                    "connection_line": "[[new-concept|New Concept]] — related.",
+                    "relevance": 8,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# New Concept\n\nBody", touch])
+
+    manifest = Manifest()
+    asyncio.run(
+        compile_cmd._run_compile_async(
+            [source],
+            manifest,
+            test_config,
+            provider,
+            dry_run=False,
+            max_touches=5,
+        )
+    )
+
+    # The touched concept must now have the new source in its manifest entry,
+    # alongside the pre-existing legacy URL parsed from frontmatter.
+    assert "existing-target" in manifest.wiki_articles
+    target_urls = manifest.wiki_articles["existing-target"].source_urls
+    assert "https://example.com/legacy" in target_urls
+    assert source.source_url in target_urls
+    assert "existing-target" in manifest.sources[source.source_url].wiki_articles
+
+
+def test_compile_cli_max_touches_flag_default_is_five(monkeypatch, test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "read_manifest", lambda vault_path: Manifest())
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+    monkeypatch.setattr(compile_cmd, "print_warning", lambda message: None)
+
+    async def fake_run(sources, manifest, config, provider, dry_run, *, max_touches=5):
+        captured["max_touches"] = max_touches
+        return (
+            compile_cmd.CompileResult(
+                articles_created=0,
+                articles_updated=0,
+                sources_compiled=len(sources),
+                errors=[],
+            ),
+            {},
+        )
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", fake_run)
+
+    compile_cmd.compile(full=False, dry_run=True, verbose=False, max_touches=5)
+
+    assert captured["max_touches"] == 5
+
 def test_compile_prints_success_on_clean_noop(monkeypatch, test_config):
     """When compile processes zero sources (no creations, updates, or errors), still print success."""
     source = _raw_source(slug="raw-a", source_url=None)
@@ -570,7 +742,7 @@ def test_compile_prints_success_on_clean_noop(monkeypatch, test_config):
     monkeypatch.setattr(compile_cmd, "print_warning", capture_warning)
     monkeypatch.setattr(compile_cmd, "print_success", capture_success)
 
-    async def fake_run(sources, manifest, config, provider, dry_run):
+    async def fake_run(sources, manifest, config, provider, dry_run, **kwargs):
         return (
             compile_cmd.CompileResult(
                 articles_created=0,
@@ -594,3 +766,58 @@ def test_compile_prints_success_on_clean_noop(monkeypatch, test_config):
     assert len(warnings_printed) == 0
     assert len(success_printed) == 1
     assert success_printed[0][0] == "Compile complete"
+
+
+def test_run_compile_async_propagation_failure_preserves_retry_hash_and_backlinks(
+    monkeypatch, test_config
+):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    concepts_dir = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+    )
+    concepts_dir.mkdir(parents=True, exist_ok=True)
+    (concepts_dir / "concept-a.md").write_text(
+        "---\ntitle: Concept A\nsources:\n"
+        f"  - {source.source_url}\n---\n\n# Concept A\n",
+        encoding="utf-8",
+    )
+    manifest = Manifest(
+        sources={
+            source.source_url: ManifestSource(
+                content_hash="previous-hash",
+                saved_at=datetime.now(UTC),
+                wiki_articles=["older-concept"],
+            )
+        }
+    )
+
+    async def fake_compile_sources(*args, **kwargs):
+        del args, kwargs
+        return (
+            compile_cmd.CompileResult(
+                articles_created=1,
+                articles_updated=0,
+                sources_compiled=1,
+                errors=["Propagation call failed"],
+                propagation_touches_by_source={source.source_url: ["touched-concept"]},
+                propagation_failed_sources={source.source_url},
+            ),
+            {"concept-a": [source.source_url]},
+        )
+
+    monkeypatch.setattr(compile_cmd, "compile_sources", fake_compile_sources)
+
+    asyncio.run(
+        compile_cmd._run_compile_async(
+            [source], manifest, test_config, provider=object(), dry_run=False
+        )
+    )
+
+    entry = manifest.sources[source.source_url]
+    assert entry.content_hash == "previous-hash"
+    assert entry.wiki_articles == ["older-concept", "concept-a", "touched-concept"]
+    assert compile_cmd.get_changed_sources(
+        manifest, {source.source_url: source.content_hash}
+    ) == [source.source_url]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -3,10 +3,31 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
+import re
 from pathlib import Path
 
-from vaultmind.ai.compiler import _deduplicate_concepts, compile_sources
+import yaml
+from structlog.testing import capture_logs
+
+from vaultmind.ai.compiler import (
+    ARTICLE_PROMPT_TOTAL_CHARS,
+    ARTICLE_SOURCE_PER_SOURCE_CHARS,
+    ARTICLE_SOURCE_REFERENCE_LIMIT,
+    ARTICLE_SOURCE_TOTAL_CHARS,
+    REQUIRED_CONCEPT_SECTIONS,
+    _create_article,
+    _deduplicate_concepts,
+    _extract_frontmatter,
+    _format_article_source_context,
+    _markdown_h2_sections,
+    _normalize_concept_body,
+    _split_page,
+    _strip_frontmatter_block,
+    _strip_model_page_wrappers,
+    compile_sources,
+)
 from vaultmind.commands.compile import _run_compile_async
 from vaultmind.core.manifest import read_manifest
 from vaultmind.core.raw_scanner import RawSourceRecord, scan_raw_sources
@@ -35,6 +56,513 @@ def _raw_source(*, slug: str, source_url: str | None = None) -> RawSourceRecord:
         content_hash=f"hash-{slug}",
         raw_tags=[],
     )
+
+
+def test_compile_sources_create_prompt_contains_resolvable_raw_packets_and_unresolved_key(
+    test_config,
+):
+    source_a = _raw_source(slug="ground-a", source_url="https://example.com/a")
+    source_b = _raw_source(slug="ground-b", source_url="https://example.com/b")
+    unresolved = "https://example.com/missing"
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Grounded Concept",
+                    "status": "new",
+                    "description": "Grounded in multiple sources",
+                    "source_urls": [source_a.source_url, source_b.source_url, unresolved],
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "## Overview\n\nGrounded article."])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source_a, source_b],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=0,
+        )
+    )
+
+    assert result.articles_created == 1
+    create_prompt = provider.prompts[1]
+    assert format(source_a.body) in create_prompt
+    assert format(source_b.body) in create_prompt
+    assert f"Source: {unresolved}\n\n[Raw source unavailable]" in create_prompt
+
+
+def test_compile_sources_update_prompt_exceeds_old_excerpt_and_bounds_raw_context(
+    test_config,
+):
+    marker = "CONTENT_AFTER_THE_OLD_800_CHARACTER_BOUNDARY"
+    sources = [
+        RawSourceRecord(
+            path=Path(f"/tmp/bounded-{index}.md"),
+            relative_path=f"Clippings/bounded-{index}",
+            title=f"Bounded {index}",
+            source_url=f"https://example.com/bounded-{index}",
+            body=(str(index) * 900) + marker + (str(index) * 9000),
+            content_hash=f"bounded-hash-{index}",
+            raw_tags=[],
+        )
+        for index in range(5)
+    ]
+    article_dir = test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    article_dir.mkdir(parents=True, exist_ok=True)
+    (article_dir / "bounded.md").write_text("# Bounded\n\nExisting", encoding="utf-8")
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Bounded",
+                    "status": "existing:bounded",
+                    "description": "Bounded source context",
+                    "source_urls": [source.source_url for source in sources],
+                    "merge_target": "bounded",
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# Bounded\n\nUpdated"])
+
+    asyncio.run(
+        compile_sources(
+            sources,
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=0,
+        )
+    )
+
+    update_prompt = provider.prompts[1]
+    assert update_prompt.count(marker) == len(sources)
+    expected_per_source = min(
+        ARTICLE_SOURCE_PER_SOURCE_CHARS,
+        ARTICLE_SOURCE_TOTAL_CHARS // len(sources),
+    )
+    assert expected_per_source > 800
+    assert all((str(index) * (expected_per_source + 1)) not in update_prompt for index in range(5))
+
+    source_lookup = {source.source_url: source for source in sources}
+    context = _format_article_source_context(
+        [source.source_url for source in sources], source_lookup
+    )
+    assert len(context) <= ARTICLE_SOURCE_TOTAL_CHARS
+    assert context == _format_article_source_context(
+        [source.source_url for source in sources], source_lookup
+    )
+
+
+def test_source_reference_limit_is_deterministic_and_consistent_across_artifacts(
+    test_config,
+):
+    source = _raw_source(slug="accepted", source_url="https://example.com/accepted")
+    long_keys = [
+        f"https://missing.example/{index:03d}/" + (chr(97 + index % 26) * 400)
+        for index in range(ARTICLE_SOURCE_REFERENCE_LIMIT + 7)
+    ]
+    submitted = [source.source_url, source.source_url, *long_keys]
+    expected = [source.source_url, *long_keys[: ARTICLE_SOURCE_REFERENCE_LIMIT - 1]]
+    dropped = long_keys[ARTICLE_SOURCE_REFERENCE_LIMIT - 1 :]
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Bounded Attribution",
+                    "status": "new",
+                    "description": "Bounded and consistent",
+                    "source_urls": submitted,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "## Overview\n\nArticle."])
+
+    with capture_logs() as logs:
+        result, slug_to_urls = asyncio.run(
+            compile_sources(
+                [source],
+                Manifest(),
+                provider,
+                test_config.vault_path,
+                test_config.folders,
+                max_touches=0,
+            )
+        )
+
+    truncations = [
+        entry for entry in logs if entry["event"] == "article_source_references_truncated"
+    ]
+    assert truncations
+    assert truncations[0]["accepted"] == ARTICLE_SOURCE_REFERENCE_LIMIT
+    assert truncations[0]["dropped"] == len(submitted) - 1 - len(expected)
+    assert result.articles_created == 1
+    assert slug_to_urls == {"bounded-attribution": expected}
+    context = provider.prompts[1].partition("Attributed source citations:\n")[2].partition(
+        "\n\nRaw source packets:"
+    )[0]
+    assert len(context.splitlines()) == ARTICLE_SOURCE_REFERENCE_LIMIT
+    for key in expected[1:]:
+        assert hashlib.sha256(key.encode()).hexdigest()[:12] in context
+    for key in dropped:
+        assert hashlib.sha256(key.encode()).hexdigest()[:12] not in context
+    lookup = {source.source_url: source}
+    assert _format_article_source_context(submitted, lookup) == _format_article_source_context(
+        submitted, lookup
+    )
+
+    page_path = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+        / "bounded-attribution.md"
+    )
+    page = page_path.read_text(encoding="utf-8")
+    frontmatter, body = page.split("---", 2)[1:]
+    assert yaml.safe_load(frontmatter)["sources"] == expected
+    sources_body = body.partition("## Sources\n")[2]
+    assert [line[2:] for line in sources_body.splitlines() if line.startswith("- ")] == expected
+
+
+def test_article_prompt_and_context_are_hard_bounded_for_pathological_attribution():
+    resolved = [
+        RawSourceRecord(
+            path=Path(f"/tmp/pathological-{index}.md"),
+            relative_path=f"Clippings/{index}",
+            title="T" * 2000,
+            source_url=f"https://example.com/resolved/{index}/" + ("r" * 1000),
+            body=f"RAW-{index}-" + ("body" * 3000),
+            content_hash=f"hash-{index}",
+            raw_tags=["tag" * 1000],
+        )
+        for index in range(120)
+    ]
+    unresolved = [f"https://missing.example/{index}/" + ("u" * 1000) for index in range(120)]
+    keys = [source.source_url for source in resolved] + unresolved
+    lookup = {source.source_url: source for source in resolved}
+
+    context = _format_article_source_context(keys, lookup)
+
+    assert len(context) <= ARTICLE_SOURCE_TOTAL_CHARS
+    citation_block, _, packet_block = context.partition("\n\nRaw source packets:\n")
+    assert len(citation_block.splitlines()) == ARTICLE_SOURCE_REFERENCE_LIMIT + 1
+    retained_keys = keys[:ARTICLE_SOURCE_REFERENCE_LIMIT]
+    for key in retained_keys:
+        assert hashlib.sha256(key.encode()).hexdigest()[:12] in citation_block
+    for key in keys[ARTICLE_SOURCE_REFERENCE_LIMIT:]:
+        assert hashlib.sha256(key.encode()).hexdigest()[:12] not in citation_block
+    for packet in packet_block.split("\n\n---\n\n"):
+        if packet and "[Raw source unavailable]" not in packet:
+            assert "Raw body:\n" in packet
+            assert packet.partition("Raw body:\n")[2]
+
+    concept = WikiConceptEntry(
+        name="Pathological prompt",
+        status=ConceptStatus.NEW,
+        description="description" * 100_000,
+        source_urls=keys,
+    )
+    provider = StubProvider(["article"])
+    asyncio.run(_create_article(concept, lookup, provider))
+    assert len(provider.prompts[0]) <= ARTICLE_PROMPT_TOTAL_CHARS
+
+
+def test_resolvable_source_is_retained_ahead_of_unresolved_reference_cap(test_config):
+    source = _raw_source(slug="grounded-last", source_url="https://example.com/grounded-last")
+    unresolved = [
+        f"https://missing.example/{index}" for index in range(ARTICLE_SOURCE_REFERENCE_LIMIT)
+    ]
+    submitted = [*unresolved, source.source_url]
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Grounded Priority",
+                    "status": "new",
+                    "description": "Must retain Raw grounding",
+                    "source_urls": submitted,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "## Overview\n\nGrounded."])
+
+    _result, slug_to_urls = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=0,
+        )
+    )
+
+    accepted = slug_to_urls["grounded-priority"]
+    assert accepted[0] == source.source_url
+    assert len(accepted) == ARTICLE_SOURCE_REFERENCE_LIMIT
+    assert "Raw body:\n# grounded-last" in provider.prompts[1]
+
+
+def test_wrapper_scanner_tracks_fence_marker_length_and_valid_closers():
+    model = (
+        "# Remove before\n"
+        "````python\n"
+        "# Keep in four-backtick fence\n"
+        "```\n"
+        "# Keep after shorter closer\n"
+        "~~~~\n"
+        "# Keep after mismatched closer\n"
+        "````   \n"
+        "   # Remove after real closer ###\n"
+        "~~~text\n"
+        "# Keep in tilde fence\n"
+        "````\n"
+        "# Keep after mismatched backticks\n"
+        "~~~~\n"
+        "# Remove after tilde closer\n"
+        "```\n"
+        "# Keep in unclosed fence\n"
+    )
+
+    cleaned = _strip_model_page_wrappers(model)
+
+    assert "Remove before" not in cleaned
+    assert "Remove after real closer" not in cleaned
+    assert "Remove after tilde closer" not in cleaned
+    assert "# Keep in four-backtick fence" in cleaned
+    assert "# Keep after shorter closer" in cleaned
+    assert "# Keep after mismatched closer" in cleaned
+    assert "# Keep in tilde fence" in cleaned
+    assert "# Keep after mismatched backticks" in cleaned
+    assert "# Keep in unclosed fence" in cleaned
+
+
+def test_wrapper_scanner_preserves_four_space_pseudo_fences_and_body_content():
+    model = (
+        "    ```\n"
+        "    # Four-space indented content\n"
+        "    ```\n"
+        "  # Remove indented H1\n"
+        "\n"
+        "  preserved body indentation  \n"
+    )
+
+    preserved = (
+        "    ```\n"
+        "    # Four-space indented content\n"
+        "    ```\n"
+        "\n"
+        "  preserved body indentation  \n"
+    )
+    assert _strip_model_page_wrappers(model) == preserved
+
+    normalized = _normalize_concept_body(model, "Canonical", [])
+    assert normalized.startswith("# Canonical\n\n")
+    assert preserved in normalized
+
+
+def test_wrapper_scanner_removes_crlf_frontmatter_atx_and_setext_h1s():
+    model = (
+        "---\r\n"
+        "title: Model title\r\n"
+        "sources: [hallucinated]\r\n"
+        "---\r\n"
+        "\r\n"
+        "   # Indented ATX title ###\r\n"
+        "Keep this paragraph exactly.  \r\n"
+        "Model setext title\r\n"
+        "   ======   \r\n"
+        "After.\r\n"
+    )
+
+    assert _strip_model_page_wrappers(model) == (
+        "\r\nKeep this paragraph exactly.  \r\nAfter.\r\n"
+    )
+
+
+def test_wrapper_scanner_accepts_longer_closer_but_not_closer_with_content():
+    model = """```lang
+# Keep one
+```` trailing
+# Keep two
+````
+# Remove outside
+"""
+
+    cleaned = _strip_model_page_wrappers(model)
+
+    assert "# Keep one" in cleaned
+    assert "# Keep two" in cleaned
+    assert "Remove outside" not in cleaned
+
+
+def test_h2_scanner_rejects_fence_closer_with_trailing_content():
+    body = """````markdown
+## Sources
+```` trailing content
+## Open Questions
+````
+## Overview
+
+Real overview.
+"""
+
+    assert [section.title for section in _markdown_h2_sections(body)] == ["Overview"]
+
+    normalized = _normalize_concept_body(body, "Fence Contract", ["https://example.com/source"])
+    titles = [section.title for section in _markdown_h2_sections(normalized)]
+    for heading in REQUIRED_CONCEPT_SECTIONS:
+        assert titles.count(heading) == 1
+
+
+def test_normalization_sanitizes_multiline_title_to_exactly_one_h1():
+    normalized = _normalize_concept_body(
+        "## Overview\n\nBody.",
+        "Good Title\n# Injected Title",
+        [],
+    )
+
+    assert normalized.startswith("# Good Title # Injected Title\n")
+    assert len(re.findall(r"^ {0,3}#(?:[ \t]+|$)", normalized, re.MULTILINE)) == 1
+
+
+def test_frontmatter_parser_requires_line_delimited_closer():
+    page = (
+        "---\r\n"
+        "title: foo---bar\r\n"
+        "sources:\r\n"
+        "  - https://example.com/original\r\n"
+        "---\r\n"
+        "\r\n"
+        "# Foo\r\n"
+    )
+
+    assert _extract_frontmatter(page) == {
+        "title": "foo---bar",
+        "sources": ["https://example.com/original"],
+    }
+    frontmatter, body = _split_page(page)
+    assert frontmatter["sources"] == ["https://example.com/original"]
+    assert body == "# Foo\r\n"
+    assert _strip_frontmatter_block(page) == "# Foo\r\n"
+
+
+def test_normalization_ignores_fenced_headings_and_consolidates_sources():
+    source = "https://example.com/managed"
+    model_body = f"""```markdown
+## Key Ideas
+## Connections
+## Open Questions
+## Sources
+- {source}
+```
+
+## Overview
+
+Real overview.
+
+## Sources
+
+- {source}
+First source note.
+
+## Sources
+
+- {source}
+Second source note.
+"""
+
+    normalized = _normalize_concept_body(model_body, "Fence Aware", [source])
+    sections = _markdown_h2_sections(normalized)
+    real_titles = [section.title for section in sections]
+
+    for heading in REQUIRED_CONCEPT_SECTIONS:
+        assert real_titles.count(heading) == 1
+    assert "First source note." in normalized
+    assert "Second source note." in normalized
+    outside_fence = normalized[normalized.index("```", normalized.index("```") + 3) + 3 :]
+    assert outside_fence.count(f"- {source}") == 1
+
+
+def test_written_concept_enforces_page_contract_and_synchronizes_sources(test_config):
+    source = _raw_source(slug="contract", source_url="https://example.com/contract")
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Human Contract Title",
+                    "status": "new",
+                    "description": "Contract test",
+                    "source_urls": [source.source_url, source.source_url],
+                }
+            ]
+        }
+    )
+    model_page = """---
+title: Model Title
+sources:
+  - https://model.example/hallucinated
+---
+
+# Model Title
+# Duplicate Leading Title
+
+Model-authored prose is retained.
+
+## Overview
+
+An overview.
+
+## Sources
+
+- https://model.example/hallucinated-body-source
+- https://example.com/contract
+- https://example.com/contract
+"""
+    provider = StubProvider([triage, model_page])
+
+    asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=0,
+        )
+    )
+
+    path = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+        / "human-contract-title.md"
+    )
+    page = path.read_text(encoding="utf-8")
+    frontmatter, body = page.split("---", 2)[1:]
+    parsed = yaml.safe_load(frontmatter)
+    assert parsed == {
+        "title": "Human Contract Title",
+        "vaultmind": True,
+        "kind": "concept",
+        "sources": [source.source_url],
+    }
+    assert re.findall(r"^#\s+.+$", body, re.MULTILINE) == ["# Human Contract Title"]
+    for heading in ("Overview", "Key Ideas", "Connections", "Open Questions", "Sources"):
+        assert f"## {heading}" in body
+    assert "Model-authored prose is retained." in body
+    assert body.count(f"- {source.source_url}") == 1
+    assert "Model Title" not in body
+    assert "https://model.example/hallucinated" not in page
+    assert "https://model.example/hallucinated-body-source" not in page
 
 
 def test_compile_sources_updates_existing_article_with_relative_path_raw_body(test_config):
@@ -126,7 +654,7 @@ def test_compile_sources_preserves_existing_frontmatter_sources_on_update(test_c
 
     updated = article_path.read_text(encoding="utf-8")
     assert result.articles_updated == 1
-    assert slug_to_urls == {"concept-a": [source.source_url]}
+    assert slug_to_urls == {"concept-a": [old_source_url, source.source_url]}
     assert "title: Human Concept A" in updated
     assert f"  - {old_source_url}" in updated
     assert f"  - {source.source_url}" in updated
@@ -176,7 +704,7 @@ def test_fixture_vault_compile_updates_existing_concept_and_preserves_sources(fi
     updated = article_path.read_text(encoding="utf-8")
 
     assert result.articles_updated == 1
-    assert slug_to_urls == {"attention-mechanisms": [source.source_url]}
+    assert slug_to_urls == {"attention-mechanisms": [old_source_url, source.source_url]}
     assert source.source_url in manifest.sources
     assert manifest.sources[source.source_url].wiki_articles == ["attention-mechanisms"]
     assert old_source_url in manifest.wiki_articles["attention-mechanisms"].source_urls
@@ -441,3 +969,909 @@ def test_compile_run_skips_manifest_update_for_failed_source(test_config):
     assert success_source.source_url in manifest.sources
     assert failing_source.source_url not in manifest.sources
     assert "success-concept" in manifest.wiki_articles
+
+
+# ---- Cross-page propagation (Stage 3) ----
+
+
+def _seed_existing_concept(
+    test_config,
+    *,
+    slug: str,
+    title: str,
+    body: str,
+    existing_sources: list[str] | None = None,
+) -> Path:
+    """Write a concept page to the vault and return its path."""
+    article_dir = (
+        test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    )
+    article_dir.mkdir(parents=True, exist_ok=True)
+    fm_lines = [
+        "---",
+        f'title: "{title}"',
+        "vaultmind: true",
+        "kind: concept",
+        "sources:",
+    ]
+    for source in existing_sources or []:
+        fm_lines.append(f"  - {source}")
+    fm_lines.append("---")
+    fm_block = "\n".join(fm_lines)
+
+    path = article_dir / f"{slug}.md"
+    path.write_text(f"{fm_block}\n\n{body}\n", encoding="utf-8")
+    return path
+
+
+def _triage_for_new_concept(name: str, slug: str, source_key: str) -> str:
+    return json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": name,
+                    "status": "new",
+                    "description": f"New concept {name}",
+                    "source_urls": [source_key],
+                    "merge_target": None,
+                }
+            ]
+        }
+    )
+
+
+def _touch_response(target_slug: str, new_slug: str, relevance: int = 7) -> str:
+    return json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": target_slug,
+                    "connection_line": (
+                        f"[[{new_slug}|New Concept]] — relates to {target_slug}."
+                    ),
+                    "relevance": relevance,
+                }
+            ]
+        }
+    )
+
+
+def test_propagation_writes_connections_bullet_to_existing_concept(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body=(
+            "# Existing Concept\n\n"
+            "## Overview\n\n"
+            "Some overview text.\n\n"
+            "## Key Ideas\n\n"
+            "- Idea one\n\n"
+            "## Connections\n\n"
+            "- [[other-concept]] — pre-existing relationship.\n\n"
+            "## Sources\n\n"
+            "- https://example.com/old-source\n"
+        ),
+        existing_sources=["https://example.com/old-source"],
+    )
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch = _touch_response("existing-concept", "new-concept", relevance=8)
+    provider = StubProvider(
+        [triage, "# New Concept\n\nBody", touch]
+    )
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 1
+    assert result.propagation_touches_by_source == {
+        source.source_url: ["existing-concept"]
+    }
+    target_path = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+        / "existing-concept.md"
+    )
+    updated = target_path.read_text(encoding="utf-8")
+    # Original sections preserved
+    assert "## Overview\n\nSome overview text." in updated
+    assert "- Idea one" in updated
+    # Connections section now includes both old + new bullet
+    assert "[[other-concept]] — pre-existing relationship." in updated
+    assert "[[new-concept|New Concept]]" in updated
+    # Sources section updated
+    assert "- https://example.com/old-source" in updated
+    assert "- https://example.com/raw-a" in updated
+
+
+def test_propagation_is_idempotent_when_target_already_links_new_slug(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body=(
+            "# Existing Concept\n\n"
+            "## Connections\n\n"
+            "- [[new-concept|New Concept]] — already linked.\n"
+        ),
+    )
+    original = target_path.read_text(encoding="utf-8")
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    # The LLM still tries to touch — propagation must skip it via the idempotency guard.
+    touch = _touch_response("existing-concept", "new-concept", relevance=9)
+    provider = StubProvider([triage, "# New Concept\n\nBody", touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 0
+    assert target_path.read_text(encoding="utf-8") == original
+
+
+def test_propagation_caps_touches_at_max_touches_choosing_highest_relevance(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    for slug in ("target-a", "target-b", "target-c", "target-d"):
+        _seed_existing_concept(
+            test_config,
+            slug=slug,
+            title=slug.replace("-", " ").title(),
+            body=f"# {slug}\n\n## Overview\n\nSummary for {slug}.\n",
+        )
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch_response = json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": "target-a",
+                    "connection_line": "[[new-concept|New Concept]] — A relates.",
+                    "relevance": 9,
+                },
+                {
+                    "target_slug": "target-b",
+                    "connection_line": "[[new-concept|New Concept]] — B relates.",
+                    "relevance": 4,
+                },
+                {
+                    "target_slug": "target-c",
+                    "connection_line": "[[new-concept|New Concept]] — C relates.",
+                    "relevance": 7,
+                },
+                {
+                    "target_slug": "target-d",
+                    "connection_line": "[[new-concept|New Concept]] — D relates.",
+                    "relevance": 6,
+                },
+            ]
+        }
+    )
+    provider = StubProvider(
+        [triage, "# New Concept\n\nBody", touch_response]
+    )
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=2,
+        )
+    )
+
+    assert result.articles_touched == 2
+    concepts_dir = (
+        test_config.vault_path / test_config.folders.wiki / test_config.folders.wiki_concepts
+    )
+    assert "[[new-concept|New Concept]]" in (concepts_dir / "target-a.md").read_text(encoding="utf-8")
+    assert "[[new-concept|New Concept]]" in (concepts_dir / "target-c.md").read_text(encoding="utf-8")
+    assert "[[new-concept|New Concept]]" not in (concepts_dir / "target-b.md").read_text(encoding="utf-8")
+    assert "[[new-concept|New Concept]]" not in (concepts_dir / "target-d.md").read_text(encoding="utf-8")
+
+
+def test_propagation_drops_touch_with_unknown_target_slug(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body="# Existing Concept\n\n## Overview\n\nSomething.\n",
+    )
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    bad_touch = json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": "not-in-catalog",
+                    "connection_line": "[[new-concept|New Concept]] — unrelated.",
+                    "relevance": 8,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# New Concept\n\nBody", bad_touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 0
+    assert result.errors == []
+
+
+def test_propagation_drops_touch_without_wikilink_to_a_new_slug(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body="# Existing Concept\n\n## Overview\n\nSomething.\n",
+    )
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    bad_touch = json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": "existing-concept",
+                    "connection_line": "[[unrelated-slug|Other]] — wrong target link.",
+                    "relevance": 8,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# New Concept\n\nBody", bad_touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 0
+
+
+def test_propagation_inserts_connections_section_when_missing_before_open_questions(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body=(
+            "# Existing Concept\n\n"
+            "## Overview\n\n"
+            "An overview.\n\n"
+            "## Open Questions\n\n"
+            "- What about X?\n\n"
+            "## Sources\n\n"
+            "- https://example.com/old-source\n"
+        ),
+        existing_sources=["https://example.com/old-source"],
+    )
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch = _touch_response("existing-concept", "new-concept", relevance=8)
+    provider = StubProvider([triage, "# New Concept\n\nBody", touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 1
+    body = target_path.read_text(encoding="utf-8")
+    connections_index = body.find("## Connections")
+    open_questions_index = body.find("## Open Questions")
+    sources_index = body.find("## Sources")
+    assert connections_index != -1
+    assert connections_index < open_questions_index < sources_index
+    assert "[[new-concept|New Concept]]" in body
+
+
+def test_propagation_inserts_connections_section_at_end_when_no_open_questions_or_sources(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body=(
+            "# Existing Concept\n\n"
+            "## Overview\n\n"
+            "An overview.\n\n"
+            "## Key Ideas\n\n"
+            "- Idea one\n"
+        ),
+    )
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch = _touch_response("existing-concept", "new-concept", relevance=8)
+    provider = StubProvider([triage, "# New Concept\n\nBody", touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 1
+    body = target_path.read_text(encoding="utf-8")
+    overview_index = body.find("## Overview")
+    key_ideas_index = body.find("## Key Ideas")
+    connections_index = body.find("## Connections")
+    sources_index = body.find("## Sources")
+    assert overview_index < key_ideas_index < connections_index < sources_index
+    assert "[[new-concept|New Concept]]" in body
+    assert "- https://example.com/raw-a" in body
+
+
+def test_propagation_adds_source_url_to_frontmatter_and_sources_section_once(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body=(
+            "# Existing Concept\n\n"
+            "## Overview\n\n"
+            "Body.\n"
+        ),
+    )
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch = _touch_response("existing-concept", "new-concept", relevance=8)
+    provider = StubProvider([triage, "# New Concept\n\nBody", touch])
+
+    result_one, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+    assert result_one.articles_touched == 1
+    after_first = target_path.read_text(encoding="utf-8")
+    # The line `- {url}` appears once in the frontmatter list and once in the
+    # `## Sources` section.
+    assert after_first.count(f"- {source.source_url}") == 2
+    # And frontmatter contains exactly one sources list entry for this URL.
+    _, _, body_first = after_first.partition("---\n\n")
+    assert body_first.count(f"- {source.source_url}") == 1
+
+    # Second compile — idempotency guard must skip touch.
+    triage_two = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch_two = _touch_response("existing-concept", "new-concept", relevance=8)
+    provider_two = StubProvider(
+        [triage_two, "# New Concept\n\nBody", touch_two]
+    )
+    result_two, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider_two,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+    assert result_two.articles_touched == 0
+    after_second = target_path.read_text(encoding="utf-8")
+    # Idempotent: should be byte-identical to the first run.
+    assert after_second == after_first
+
+
+def test_propagation_excludes_self_for_concepts_created_this_run(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    # Pre-create a concept page with the SAME slug as the new concept the LLM
+    # will return — this simulates a concept that was created earlier in the
+    # same compile run.
+    _seed_existing_concept(
+        test_config,
+        slug="new-concept",
+        title="New Concept",
+        body="# New Concept\n\n## Overview\n\nExisting.\n",
+    )
+    _seed_existing_concept(
+        test_config,
+        slug="other-concept",
+        title="Other Concept",
+        body="# Other Concept\n\n## Overview\n\nOther summary.\n",
+    )
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "New Concept",
+                    "status": "existing:new-concept",
+                    "description": "Reusing the existing slug",
+                    "source_urls": [source.source_url],
+                    "merge_target": "new-concept",
+                }
+            ]
+        }
+    )
+    # No touches needed — return empty list.
+    touch = json.dumps({"touches": []})
+    # update path runs the article-update prompt instead of create
+    provider = StubProvider([triage, "# New Concept\n\nUpdated", touch])
+
+    asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    # The 3rd prompt (index 2) is the propagation call.
+    assert len(provider.prompts) >= 3
+    propagation_prompt = provider.prompts[2]
+    # Catalog must contain other-concept but NOT new-concept.
+    assert "other-concept |" in propagation_prompt
+    assert "- new-concept |" not in propagation_prompt
+
+
+def test_propagation_dry_run_makes_no_call_and_no_write(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body="# Existing Concept\n\n## Overview\n\nBody.\n",
+    )
+    original = target_path.read_text(encoding="utf-8")
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    provider = StubProvider([triage])  # ONLY triage — no touch response
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            dry_run=True,
+            max_touches=5,
+        )
+    )
+
+    assert result.articles_touched == 0
+    assert provider.responses == []
+    assert target_path.read_text(encoding="utf-8") == original
+
+
+def test_propagation_zero_max_touches_disables_stage(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body="# Existing Concept\n\n## Overview\n\nBody.\n",
+    )
+    original = target_path.read_text(encoding="utf-8")
+
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    # Only triage + article create — no touch response.
+    provider = StubProvider([triage, "# New Concept\n\nBody"])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=0,
+        )
+    )
+
+    assert result.articles_touched == 0
+    assert provider.responses == []
+    assert target_path.read_text(encoding="utf-8") == original
+
+
+def test_propagation_error_recorded_and_does_not_abort_other_sources(
+    test_config, monkeypatch
+):
+    source_a = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    source_b = _raw_source(slug="raw-b", source_url="https://example.com/raw-b")
+    _seed_existing_concept(
+        test_config,
+        slug="target-a",
+        title="Target A",
+        body="# Target A\n\n## Overview\n\nA body.\n",
+    )
+    target_b_path = _seed_existing_concept(
+        test_config,
+        slug="target-b",
+        title="Target B",
+        body="# Target B\n\n## Overview\n\nB body.\n",
+    )
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Concept A",
+                    "status": "new",
+                    "description": "A new",
+                    "source_urls": [source_a.source_url],
+                    "merge_target": None,
+                },
+                {
+                    "name": "Concept B",
+                    "status": "new",
+                    "description": "B new",
+                    "source_urls": [source_b.source_url],
+                    "merge_target": None,
+                },
+            ]
+        }
+    )
+    dedup = triage  # Same — no merge.
+    touch_a = _touch_response("target-a", "concept-a", relevance=8)
+    touch_b = _touch_response("target-b", "concept-b", relevance=8)
+    provider = StubProvider(
+        [
+            triage,
+            dedup,
+            "# Concept A\n\nA body",
+            "# Concept B\n\nB body",
+            touch_a,
+            touch_b,
+        ]
+    )
+
+    # Monkeypatch write_markdown_page to fail ONCE — for target-a only.
+    from vaultmind.ai import compiler as compiler_module
+
+    original_write = compiler_module.write_markdown_page
+
+    def flaky_write(path, *, body, frontmatter=None):
+        if path.stem == "target-a":
+            raise RuntimeError("boom")
+        return original_write(path, body=body, frontmatter=frontmatter)
+
+    monkeypatch.setattr(compiler_module, "write_markdown_page", flaky_write)
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source_a, source_b],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 1
+    assert result.propagation_failed_sources == {source_a.source_url}
+    assert result.propagation_touches_by_source == {source_b.source_url: ["target-b"]}
+    assert any(
+        "Propagation touch on 'target-a' from 'https://example.com/raw-a' failed:" in err
+        for err in result.errors
+    )
+    # target-b was written successfully.
+    body_b = target_b_path.read_text(encoding="utf-8")
+    assert "[[concept-b|New Concept]]" in body_b
+
+
+def test_propagation_idempotency_ignores_wikilink_inside_code_block(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="existing-concept",
+        title="Existing Concept",
+        body=(
+            "# Existing Concept\n\n"
+            "## Connections\n\n"
+            "Here is how you would write a wikilink:\n\n"
+            "```markdown\n"
+            "[[new-slug]] (this is doc syntax, not a real link)\n"
+            "```\n"
+        ),
+    )
+
+    triage = _triage_for_new_concept("New Slug", "new-slug", source.source_url)
+    touch = _touch_response("existing-concept", "new-slug", relevance=8)
+    provider = StubProvider([triage, "# New Slug\n\nBody", touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 1
+    updated = target_path.read_text(encoding="utf-8")
+    # The fenced code block must be preserved verbatim.
+    assert "```markdown\n[[new-slug]] (this is doc syntax, not a real link)\n```" in updated
+    # The real propagation bullet was appended exactly once (display text is
+    # the touch_response helper's hard-coded "New Concept").
+    bullet = "- [[new-slug|New Concept]] — relates to existing-concept."
+    assert updated.count(bullet) == 1
+
+
+def test_propagation_normalizes_target_slug_case_and_whitespace(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="target",
+        title="Target",
+        body="# Target\n\n## Overview\n\nTarget body.\n",
+    )
+
+    # Concept name slugifies to "new-slug" so the new_slugs set matches the
+    # connection_line wikilink target below.
+    triage = _triage_for_new_concept("New Slug", "new-slug", source.source_url)
+    touch = json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": " Target  ",
+                    "connection_line": "[[new-slug|New]] — relates.",
+                    "relevance": 7,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# New Slug\n\nBody", touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 1
+    updated = target_path.read_text(encoding="utf-8")
+    assert "- [[new-slug|New]] — relates." in updated
+
+
+def test_compile_result_articles_touched_counts_distinct_targets(test_config):
+    source_a = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    source_b = _raw_source(slug="raw-b", source_url="https://example.com/raw-b")
+    _seed_existing_concept(
+        test_config,
+        slug="shared-target",
+        title="Shared Target",
+        body="# Shared Target\n\n## Overview\n\nShared body.\n",
+    )
+
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Concept A",
+                    "status": "new",
+                    "description": "A new",
+                    "source_urls": [source_a.source_url],
+                    "merge_target": None,
+                },
+                {
+                    "name": "Concept B",
+                    "status": "new",
+                    "description": "B new",
+                    "source_urls": [source_b.source_url],
+                    "merge_target": None,
+                },
+            ]
+        }
+    )
+    dedup = triage
+    touch_a = _touch_response("shared-target", "concept-a", relevance=8)
+    touch_b = _touch_response("shared-target", "concept-b", relevance=8)
+    provider = StubProvider(
+        [
+            triage,
+            dedup,
+            "# Concept A\n\nA body",
+            "# Concept B\n\nB body",
+            touch_a,
+            touch_b,
+        ]
+    )
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source_a, source_b],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    assert result.articles_touched == 1
+
+
+def test_propagation_same_concept_multi_source_uses_current_disk_idempotency(test_config):
+    source_a = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    source_b = _raw_source(slug="raw-b", source_url="https://example.com/raw-b")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="shared-target",
+        title="Shared Target",
+        body="# Shared Target\n\n## Connections\n",
+    )
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Shared New Concept",
+                    "status": "new",
+                    "description": "Shared by two sources",
+                    "source_urls": [source_a.source_url, source_b.source_url],
+                    "merge_target": None,
+                }
+            ]
+        }
+    )
+    touch = _touch_response("shared-target", "shared-new-concept", relevance=8)
+    provider = StubProvider([triage, "# Shared New Concept\n\nBody", touch, touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source_a, source_b],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+        )
+    )
+
+    updated = target_path.read_text(encoding="utf-8")
+    assert result.articles_touched == 1
+    assert updated.count("[[shared-new-concept|New Concept]]") == 1
+
+
+def test_propagation_accepts_canonical_allowed_wikilink_forms(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="target",
+        title="Target",
+        body="# Target\n\n## Overview\n\nBody.\n",
+    )
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch = json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": "target",
+                    "connection_line": (
+                        "[[new-concept|alias]], [[Wiki/Concepts/new-concept#Heading]], "
+                        "[[new-concept^block]], and [[new-concept.md]] are related."
+                    ),
+                    "relevance": 8,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# New Concept\n\nBody", touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source], Manifest(), provider, test_config.vault_path, test_config.folders
+        )
+    )
+
+    assert result.articles_touched == 1
+    assert "[[Wiki/Concepts/new-concept#Heading]]" in target_path.read_text(encoding="utf-8")
+
+
+def test_propagation_rejects_line_with_any_unauthorized_wikilink(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="target",
+        title="Target",
+        body="# Target\n\n## Overview\n\nBody.\n",
+    )
+    original = target_path.read_text(encoding="utf-8")
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+    touch = json.dumps(
+        {
+            "touches": [
+                {
+                    "target_slug": "target",
+                    "connection_line": (
+                        "[[new-concept|allowed]] but also "
+                        "[[Wiki/Concepts/unauthorized.md#Heading|not allowed]]."
+                    ),
+                    "relevance": 8,
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "# New Concept\n\nBody", touch])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source], Manifest(), provider, test_config.vault_path, test_config.folders
+        )
+    )
+
+    assert result.articles_touched == 0
+    assert target_path.read_text(encoding="utf-8") == original
+
+
+def test_propagation_call_failure_marks_source_for_retry(test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    _seed_existing_concept(
+        test_config,
+        slug="target",
+        title="Target",
+        body="# Target\n\n## Overview\n\nBody.\n",
+    )
+    triage = _triage_for_new_concept("New Concept", "new-concept", source.source_url)
+
+    class FailingPropagationProvider(StubProvider):
+        async def complete(self, prompt: str, system: str = "") -> str:
+            if len(self.prompts) == 2:
+                self.prompts.append(prompt)
+                raise RuntimeError("provider unavailable")
+            return await super().complete(prompt, system)
+
+    provider = FailingPropagationProvider([triage, "# New Concept\n\nBody"])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source], Manifest(), provider, test_config.vault_path, test_config.folders
+        )
+    )
+
+    assert result.propagation_failed_sources == {source.source_url}
+    assert any("Propagation call" in error for error in result.errors)


### PR DESCRIPTION
## Summary

- ground concept creation and updates in bounded Raw source packets
- enforce deterministic concept-page contracts and synchronized provenance
- add conservative, retryable cross-page connection propagation
- make filed query answers searchable by later questions
- implement genuine three-pass deep Ask with persisted follow-up gaps
- make Ask preview strictly no-write

## Integrity guarantees

- propagation writes remain idempotent and constrained to approved wikilinks
- failed propagation sources remain eligible for incremental retry
- manifest provenance is reconciled in both directions
- concept and query pages receive exactly one H1 and their required sections
- provider output and source attribution are deterministically bounded
- repeated questions cannot cite or consume the page they overwrite

## Verification

```text
uv run ruff check
uv run mypy src/vaultmind
uv run pytest
```

All checks pass; 172 tests pass.
