### PR TITLE
Reconcile vault manifest state safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ It should:
 
 Compile should be conservative. Updating an existing concept page is usually better than creating a duplicate page. Article generation and updates are grounded in bounded Raw source packets, and VaultMind deterministically enforces the concept-page headings and synchronizes source citations before each atomic write.
 
+Before diffing Raw sources, compile reconciles the manifest with concept pages on disk. Concept membership, content hashes, frontmatter citations, and source back-references are repaired from those pages. Missing uncited Raw entries are removed, while historical sources still cited by a concept are preserved. Reconciliation never marks a current Raw file as compiled. Repair-only runs persist the repaired manifest and log the repair; concept membership changes also rebuild the index.
+
 ### Ask
 
 Ask is the second compounding loop.
@@ -254,7 +256,8 @@ vm version     # print the version
 No-write/preview modes keep every command safe to dry-run:
 
 ```bash
-vm compile --dry-run          # show what would compile; no writes or propagation calls
+vm compile --dry-run          # show compilation and reconciliation; write nothing
+vm compile --full             # force all current Raw through compile; preserve Wiki and history
 vm compile --max-touches 5    # cap existing pages touched per source (0 disables propagation)
 vm ask "..." --preview        # print the answer without filing it
 vm lint --preview      # print the health report without writing it
@@ -268,7 +271,14 @@ propagation is idempotent against the page currently on disk. If a propagation
 provider call or page write fails, that source's current hash is not recorded;
 the command exits non-zero and the next incremental compile retries the source.
 Touches that were written before a later failure remain recorded in both manifest
-directions. `--dry-run` performs neither propagation calls nor writes.
+directions. `--dry-run` performs neither propagation calls nor writes. `--full` is
+non-destructive: it forces every current Raw source through compilation without
+resetting manifest provenance or deleting Wiki pages.
+
+A missing `vault.manifest.json` starts as an empty version-1 manifest. If an
+existing manifest is malformed, unreadable, schema-invalid, or has an unsupported
+version, compile and lint stop with a non-zero exit before writing anything. The
+file is never silently replaced; repair it or restore a recoverable copy first.
 
 See `vm <command> --help` for all flags.
 

--- a/src/vaultmind/commands/compile.py
+++ b/src/vaultmind/commands/compile.py
@@ -22,8 +22,11 @@ from vaultmind.ai.compiler import CompileResult, compile_sources, rebuild_index
 from vaultmind.ai.providers import Provider, get_provider
 from vaultmind.config import AppConfig, load_config
 from vaultmind.core.manifest import (
+    ManifestReadError,
+    ManifestReconciliation,
     get_changed_sources,
     read_manifest,
+    reconcile_manifest,
     update_compiled_at,
     upsert_source,
     upsert_wiki_article,
@@ -47,8 +50,47 @@ def _validate_max_touches(value: int) -> int:
     return value
 
 
+def _concepts_dir(config: AppConfig) -> Path:
+    return config.vault_path / config.folders.wiki / config.folders.wiki_concepts
+
+
+def _report_reconciliation(
+    reconciliation: ManifestReconciliation,
+    *,
+    dry_run: bool,
+) -> None:
+    if not reconciliation.changed:
+        return
+    prefix = "Planned manifest reconciliation" if dry_run else "Manifest reconciliation"
+    print_info(f"{prefix}: {len(reconciliation.repairs)} repair(s)")
+    for repair in reconciliation.repairs:
+        print_info(f"  - {repair}")
+
+
+def _persist_repairs(
+    config: AppConfig,
+    reconciliation: ManifestReconciliation,
+    *,
+    provider: Provider | None,
+) -> None:
+    if not reconciliation.changed:
+        return
+    write_manifest(config.vault_path, reconciliation.manifest)
+    append_wiki_log(
+        config,
+        event="manifest repair",
+        detail=f"{len(reconciliation.repairs)} repair(s)",
+    )
+    if reconciliation.concept_membership_changed and provider is not None:
+        _rebuild_wiki_index(config, reconciliation.manifest, provider)
+
+
 def compile(
-    full: bool = typer.Option(False, "--full", help="Full rebuild — skip manifest diff"),
+    full: bool = typer.Option(
+        False,
+        "--full",
+        help="Force recompilation of all Raw sources without resetting manifest state",
+    ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would change without writing"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Debug logging"),
     max_touches: int = typer.Option(
@@ -69,51 +111,72 @@ def compile(
     setup_logging(verbose=verbose)
     config = load_config()
 
-    manifest = read_manifest(config.vault_path)
+    try:
+        manifest = read_manifest(config.vault_path)
+    except ManifestReadError as exc:
+        print_warning(
+            f"Manifest is unreadable; refusing to compile or write to the vault. {exc}"
+        )
+        raise typer.Exit(1) from exc
 
-    # Scan raw sources from the Raw/ folder (populated by Obsidian Web Clipper)
+    # Scan Raw and reconcile only against canonical state already on disk. Raw
+    # entries are deliberately not inserted until their compilation succeeds.
     all_sources = scan_raw_sources(config)
+    raw_keys = {source.source_url or source.relative_path for source in all_sources}
+    pre_reconciliation = reconcile_manifest(
+        manifest,
+        concepts_dir=_concepts_dir(config),
+        current_raw_keys=raw_keys,
+    )
+    manifest = pre_reconciliation.manifest
+    _report_reconciliation(pre_reconciliation, dry_run=dry_run)
+
     if not all_sources:
+        if not dry_run:
+            _persist_repairs(config, pre_reconciliation, provider=None)
+            if pre_reconciliation.concept_membership_changed:
+                provider = get_provider(config, tier="deep")
+                _rebuild_wiki_index(config, manifest, provider)
         print_warning(
             f"No raw sources found in {config.folders.raw}/. "
             "Add articles via Obsidian Web Clipper first."
         )
         return
 
-    # Build source key -> record map (key is source_url, fallback to relative_path)
-    source_key_to_source = {s.source_url or s.relative_path: s for s in all_sources}
-
-    # Determine which sources to compile
+    source_key_to_source = {source.source_url or source.relative_path: source for source in all_sources}
     if full:
         sources_to_compile = all_sources
-        print_info(f"Full rebuild: {len(sources_to_compile)} raw sources")
+        print_info(f"Forced full recompile: {len(sources_to_compile)} raw sources")
     else:
-        source_hashes = {s.source_url or s.relative_path: s.content_hash for s in all_sources}
-        changed_source_keys = get_changed_sources(
-            manifest,
-            {k: v for k, v in source_hashes.items() if k is not None},
-        )
+        source_hashes = {
+            source.source_url or source.relative_path: source.content_hash
+            for source in all_sources
+        }
+        changed_source_keys = get_changed_sources(manifest, source_hashes)
         sources_to_compile = [
             source_key_to_source[key]
             for key in changed_source_keys
             if key in source_key_to_source
         ]
-        if not sources_to_compile:
-            print_success("All sources are up to date", "Nothing to compile.")
-            return
-        print_info(f"Incremental compile: {len(sources_to_compile)} new/changed sources")
+        if sources_to_compile:
+            print_info(f"Incremental compile: {len(sources_to_compile)} new/changed sources")
 
     if not sources_to_compile:
-        print_warning("No sources to compile.")
+        if dry_run:
+            print_success("Dry run", "No Raw sources would be compiled.")
+        elif pre_reconciliation.changed:
+            repair_provider = (
+                get_provider(config, tier="deep")
+                if pre_reconciliation.concept_membership_changed
+                else None
+            )
+            _persist_repairs(config, pre_reconciliation, provider=repair_provider)
+            print_success("Manifest repaired", "No Raw sources needed compilation.")
+        else:
+            print_success("All sources are up to date", "Nothing to compile.")
         return
 
-    # On full rebuild, reset manifest to start fresh
-    if full:
-        manifest = Manifest()
-
-    # Run compile pipeline
     provider = get_provider(config, tier="deep")
-
     result, slug_to_urls = asyncio.run(
         _run_compile_async(
             sources_to_compile,
@@ -126,14 +189,39 @@ def compile(
     )
 
     if dry_run:
-        print_success(
-            "Dry run",
-            _render_dry_run_summary(sources_to_compile, slug_to_urls),
-        )
+        print_success("Dry run", _render_dry_run_summary(sources_to_compile, slug_to_urls))
         return
 
-    # Write wiki index
-    if result.articles_created > 0 or result.articles_updated > 0:
+    post_reconciliation = reconcile_manifest(
+        manifest,
+        concepts_dir=_concepts_dir(config),
+        current_raw_keys=raw_keys,
+    )
+    manifest = post_reconciliation.manifest
+    if post_reconciliation.changed:
+        write_manifest(config.vault_path, manifest)
+
+    if pre_reconciliation.changed:
+        # _run_compile_async may already have persisted compile state. Record the
+        # independent disk repair so repair activity remains visible.
+        append_wiki_log(
+            config,
+            event="manifest repair",
+            detail=f"{len(pre_reconciliation.repairs)} repair(s)",
+        )
+        if not (
+            result.articles_created
+            or result.articles_updated
+            or result.articles_touched
+            or post_reconciliation.changed
+        ):
+            write_manifest(config.vault_path, manifest)
+
+    membership_changed = (
+        pre_reconciliation.concept_membership_changed
+        or post_reconciliation.concept_membership_changed
+    )
+    if result.articles_created > 0 or result.articles_updated > 0 or membership_changed:
         _rebuild_wiki_index(config, manifest, provider)
 
     # Print success unless we're in the full-failure case

--- a/src/vaultmind/commands/lint.py
+++ b/src/vaultmind/commands/lint.py
@@ -24,10 +24,10 @@ from vaultmind.core.linter import (
     lint_vault,
     render_lint_markdown,
 )
-from vaultmind.core.manifest import read_manifest
+from vaultmind.core.manifest import ManifestReadError, read_manifest
 from vaultmind.core.raw_scanner import scan_raw_sources
 from vaultmind.core.writer import write_markdown_page
-from vaultmind.utils.display import console, print_info
+from vaultmind.utils.display import console, print_info, print_warning
 from vaultmind.utils.logging import setup_logging
 
 log = structlog.get_logger()
@@ -46,9 +46,17 @@ def lint(
     setup_logging(verbose=verbose)
     config = load_config()
 
-    # Gather materials from disk
+    # Refuse before creating a report directory or writing any vault state.
+    try:
+        manifest = read_manifest(config.vault_path)
+    except ManifestReadError as exc:
+        print_warning(
+            f"Manifest is unreadable; refusing to lint or write a report. {exc}"
+        )
+        raise typer.Exit(1) from exc
+
+    # Gather remaining materials from disk.
     raw_sources = scan_raw_sources(config)
-    manifest = read_manifest(config.vault_path)
 
     # Build concept_pages from 🗺️ Wiki/🧠 Concepts/*.md
     concept_pages = _scan_concept_pages(config)

--- a/src/vaultmind/core/linter.py
+++ b/src/vaultmind/core/linter.py
@@ -326,6 +326,40 @@ def check_stale_index(
     return findings
 
 
+def check_stale_manifest(
+    raw_sources: list[Any],
+    manifest: Any,
+    concept_pages: list[ConceptPage],
+) -> list[LintFinding]:
+    """Report manifest concepts missing on disk and missing uncited Raw sources."""
+    findings: list[LintFinding] = []
+    concept_slugs = {page.slug for page in concept_pages}
+    cited_sources = {source for page in concept_pages for source in page.sources}
+    raw_keys = {source.source_url or source.relative_path for source in raw_sources}
+
+    for slug in sorted(set(manifest.wiki_articles) - concept_slugs):
+        findings.append(
+            LintFinding(
+                code="stale_manifest_concept",
+                severity=LintSeverity.WARNING,
+                message="Manifest concept page is missing from disk",
+                subject=slug,
+            )
+        )
+
+    for source_key in sorted(set(manifest.sources) - raw_keys - cited_sources):
+        findings.append(
+            LintFinding(
+                code="stale_manifest_source",
+                severity=LintSeverity.WARNING,
+                message="Manifest Raw source is missing and cited by no concept",
+                subject=source_key,
+            )
+        )
+
+    return findings
+
+
 def check_duplicate_concepts(
     concept_pages: list[ConceptPage],
 ) -> list[LintFinding]:
@@ -402,7 +436,10 @@ def lint_vault(
     # Check 5: stale_index_entry
     findings.extend(check_stale_index(index_text, concept_slugs))
 
-    # Check 6: duplicate_concept
+    # Check 6: stale manifest state
+    findings.extend(check_stale_manifest(raw_sources, manifest, concept_pages))
+
+    # Check 7: duplicate_concept
     findings.extend(check_duplicate_concepts(concept_pages))
 
     return LintReport(findings=findings)
@@ -434,6 +471,8 @@ def render_lint_markdown(report: LintReport, *, date_label: str) -> str:
         "orphan_raw",
         "sourceless_wiki",
         "stale_index_entry",
+        "stale_manifest_concept",
+        "stale_manifest_source",
         "duplicate_concept",
     ]
 
@@ -457,6 +496,8 @@ def render_lint_markdown(report: LintReport, *, date_label: str) -> str:
             "orphan_raw": "Orphan Raw Sources",
             "sourceless_wiki": "Sourceless Wiki Concepts",
             "stale_index_entry": "Stale Index Entries",
+            "stale_manifest_concept": "Missing Manifest Concept Pages",
+            "stale_manifest_source": "Missing Manifest Raw Sources",
             "duplicate_concept": "Duplicate Concepts",
         }
         title = code_titles.get(code, code)

--- a/src/vaultmind/core/manifest.py
+++ b/src/vaultmind/core/manifest.py
@@ -1,22 +1,50 @@
-"""Vault manifest — source of truth for the compile loop.
-
-vault.manifest.json lives at the vault root. It tracks:
-- Which sources have been compiled
-- Which wiki articles exist and what sources they came from
-- Content hashes to detect changes
-
-This is what makes vm compile incremental instead of a full rebuild.
-"""
+"""Vault manifest persistence and deterministic disk reconciliation."""
 
 from __future__ import annotations
 
 import json
+from collections.abc import Collection
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+import yaml
+from pydantic import ValidationError
+
 from vaultmind.schemas import Manifest, ManifestSource, ManifestWikiEntry
+from vaultmind.utils.hashing import content_hash
 
 MANIFEST_FILENAME = "vault.manifest.json"
+
+
+class ManifestReadError(Exception):
+    """The existing manifest cannot be read safely."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Cannot read manifest {path}: {reason}")
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestReconciliation:
+    """A reconciled manifest and a deterministic description of its repairs."""
+
+    manifest: Manifest
+    repairs: tuple[str, ...]
+    concept_membership_changed: bool
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.repairs)
+
+
+@dataclass(frozen=True, slots=True)
+class _DiskConcept:
+    slug: str
+    content_hash: str
+    source_urls: tuple[str, ...]
+    modified_at: datetime
 
 
 def manifest_path(vault_path: Path) -> Path:
@@ -24,16 +52,27 @@ def manifest_path(vault_path: Path) -> Path:
 
 
 def read_manifest(vault_path: Path) -> Manifest:
-    """Load the manifest from disk. Returns empty Manifest if file doesn't exist."""
+    """Load a manifest, returning an empty v1 manifest only when it is absent."""
     path = manifest_path(vault_path)
-    if not path.exists():
+    try:
+        path.lstat()
+    except FileNotFoundError:
         return Manifest()
+    except OSError as exc:
+        raise ManifestReadError(path, str(exc)) from exc
 
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("manifest must be a JSON object")
+        raw_version = data.get("version")
+        if type(raw_version) is not int or raw_version != 1:
+            raise ValueError(
+                f"invalid manifest version {raw_version!r}; expected integer 1"
+            )
         return Manifest.model_validate(data)
-    except (OSError, json.JSONDecodeError):
-        return Manifest()
+    except (OSError, UnicodeError, json.JSONDecodeError, ValidationError, ValueError) as exc:
+        raise ManifestReadError(path, str(exc)) from exc
 
 
 def write_manifest(vault_path: Path, manifest: Manifest) -> None:
@@ -41,7 +80,6 @@ def write_manifest(vault_path: Path, manifest: Manifest) -> None:
     path = manifest_path(vault_path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Atomic write: temp file + rename
     tmp = path.with_suffix(".json.tmp")
     try:
         tmp.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
@@ -49,6 +87,114 @@ def write_manifest(vault_path: Path, manifest: Manifest) -> None:
     except Exception:
         tmp.unlink(missing_ok=True)
         raise
+
+
+def reconcile_manifest(
+    manifest: Manifest,
+    *,
+    concepts_dir: Path,
+    current_raw_keys: Collection[str],
+) -> ManifestReconciliation:
+    """Reconcile persisted state against canonical concept pages and Raw inventory.
+
+    Concept membership, hashes, citations, and source back-references come from
+    concept files on disk. Current Raw files are used only to decide whether an
+    uncited historical source is stale; reconciliation never marks Raw as compiled.
+    """
+    reconciled = manifest.model_copy(deep=True)
+    disk_concepts = _scan_disk_concepts(concepts_dir)
+    old_slugs = set(reconciled.wiki_articles)
+    new_slugs = set(disk_concepts)
+    repairs: list[str] = []
+
+    for slug in sorted(old_slugs - new_slugs):
+        repairs.append(f"removed missing concept entry: {slug}")
+
+    wiki_articles: dict[str, ManifestWikiEntry] = {}
+    for slug in sorted(disk_concepts):
+        concept = disk_concepts[slug]
+        existing = reconciled.wiki_articles.get(slug)
+        source_urls = list(concept.source_urls)
+        if existing is None:
+            repairs.append(f"added concept entry from disk: {slug}")
+            last_updated = concept.modified_at
+        else:
+            last_updated = existing.last_updated
+            if existing.content_hash != concept.content_hash:
+                repairs.append(f"repaired concept hash: {slug}")
+            if existing.source_urls != source_urls:
+                repairs.append(f"repaired concept sources: {slug}")
+        wiki_articles[slug] = ManifestWikiEntry(
+            last_updated=last_updated,
+            source_urls=source_urls,
+            content_hash=concept.content_hash,
+        )
+    reconciled.wiki_articles = wiki_articles
+
+    backlinks: dict[str, list[str]] = {}
+    for slug, concept in disk_concepts.items():
+        for source_key in concept.source_urls:
+            backlinks.setdefault(source_key, []).append(slug)
+
+    raw_keys = set(current_raw_keys)
+    sources: dict[str, ManifestSource] = {}
+    for source_key in sorted(reconciled.sources):
+        entry = reconciled.sources[source_key]
+        canonical_backlinks = sorted(backlinks.get(source_key, []))
+        if source_key not in raw_keys and not canonical_backlinks:
+            repairs.append(f"removed missing uncited Raw source: {source_key}")
+            continue
+        if entry.wiki_articles != canonical_backlinks:
+            repairs.append(f"repaired source back-references: {source_key}")
+            entry = entry.model_copy(update={"wiki_articles": canonical_backlinks})
+        sources[source_key] = entry
+    reconciled.sources = sources
+
+    return ManifestReconciliation(
+        manifest=reconciled,
+        repairs=tuple(repairs),
+        concept_membership_changed=old_slugs != new_slugs,
+    )
+
+
+def _scan_disk_concepts(concepts_dir: Path) -> dict[str, _DiskConcept]:
+    if not concepts_dir.exists():
+        return {}
+
+    concepts: dict[str, _DiskConcept] = {}
+    for path in sorted(concepts_dir.glob("*.md"), key=lambda item: item.name):
+        text = path.read_text(encoding="utf-8")
+        concepts[path.stem] = _DiskConcept(
+            slug=path.stem,
+            content_hash=content_hash(text),
+            source_urls=tuple(_extract_sources(text)),
+            modified_at=datetime.fromtimestamp(path.stat().st_mtime, tz=UTC),
+        )
+    return concepts
+
+
+def _extract_sources(markdown: str) -> list[str]:
+    if not markdown.startswith("---"):
+        return []
+    end = markdown.find("---", 3)
+    if end == -1:
+        return []
+    try:
+        data = yaml.safe_load(markdown[3:end])
+    except yaml.YAMLError:
+        return []
+    if not isinstance(data, dict):
+        return []
+    value = data.get("sources")
+    candidates = value if isinstance(value, list) else [value] if isinstance(value, str) else []
+    sources: list[str] = []
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        normalized = candidate.strip()
+        if normalized and normalized not in sources:
+            sources.append(normalized)
+    return sources
 
 
 def upsert_source(
@@ -97,28 +243,19 @@ def upsert_wiki_article(
     )
 
 
-def is_source_new_or_changed(
-    manifest: Manifest,
-    url: str,
-    current_hash: str,
-) -> bool:
+def is_source_new_or_changed(manifest: Manifest, url: str, current_hash: str) -> bool:
     """Return True if the source is new or its content hash has changed."""
     existing = manifest.sources.get(url)
-    if existing is None:
-        return True
-    return existing.content_hash != current_hash
+    return existing is None or existing.content_hash != current_hash
 
 
-def get_changed_sources(
-    manifest: Manifest,
-    source_hashes: dict[str, str],
-) -> list[str]:
-    """Return list of source URLs that are new or have changed content hashes."""
-    changed = []
-    for url, current_hash in source_hashes.items():
-        if is_source_new_or_changed(manifest, url, current_hash):
-            changed.append(url)
-    return changed
+def get_changed_sources(manifest: Manifest, source_hashes: dict[str, str]) -> list[str]:
+    """Return source keys that are new or have changed content hashes."""
+    return [
+        url
+        for url, current_hash in source_hashes.items()
+        if is_source_new_or_changed(manifest, url, current_hash)
+    ]
 
 
 def update_compiled_at(manifest: Manifest) -> None:

--- a/tests/test_commands/test_compile.py
+++ b/tests/test_commands/test_compile.py
@@ -7,10 +7,11 @@ import contextlib
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
 import typer
 
 from vaultmind.commands import compile as compile_cmd
-from vaultmind.core.manifest import read_manifest
+from vaultmind.core.manifest import read_manifest, write_manifest
 from vaultmind.core.raw_scanner import RawSourceRecord
 from vaultmind.core.wiki_log import wiki_log_path
 from vaultmind.schemas import Manifest, ManifestSource, ManifestWikiEntry
@@ -31,6 +32,201 @@ def _raw_source(
         content_hash=f"hash-{slug}",
         raw_tags=[],
     )
+
+
+def test_compile_refuses_corrupted_manifest_without_writes(monkeypatch, test_config):
+    manifest_path = test_config.vault_path / "vault.manifest.json"
+    manifest_path.write_text("{broken", encoding="utf-8")
+    original = manifest_path.read_bytes()
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    warnings: list[str] = []
+    monkeypatch.setattr(compile_cmd, "print_warning", warnings.append)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        compile_cmd.compile(full=False, dry_run=False, verbose=False)
+
+    assert exc_info.value.exit_code == 1
+    assert "refusing to compile" in warnings[0]
+    assert manifest_path.read_bytes() == original
+    assert not wiki_log_path(test_config).exists()
+
+
+def test_compile_full_preserves_manifest_history(monkeypatch, test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    historical = "https://example.com/history"
+    concepts_dir = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+    )
+    concepts_dir.mkdir(parents=True)
+    (concepts_dir / "concept-a.md").write_text(
+        f"---\nsources:\n  - {historical}\n---\n\n# Concept A\n",
+        encoding="utf-8",
+    )
+    now = datetime.now(UTC)
+    manifest = Manifest(
+        sources={
+            historical: ManifestSource(
+                content_hash="historical-hash",
+                saved_at=now,
+                wiki_articles=["concept-a"],
+            ),
+            source.source_url: ManifestSource(
+                content_hash=source.content_hash,
+                saved_at=now,
+            ),
+        },
+        wiki_articles={
+            "concept-a": ManifestWikiEntry(
+                last_updated=now,
+                source_urls=[historical],
+                content_hash="old-hash",
+            )
+        },
+    )
+    captured: dict[str, Manifest] = {}
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "read_manifest", lambda vault_path: manifest)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+    monkeypatch.setattr(compile_cmd, "print_warning", lambda message: None)
+
+    async def fake_run(sources, manifest_arg, config, provider, dry_run, **kwargs):
+        captured["manifest"] = manifest_arg.model_copy(deep=True)
+        assert sources == [source]
+        return compile_cmd.CompileResult(0, 0, 1, []), {}
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", fake_run)
+    compile_cmd.compile(full=True, dry_run=True, verbose=False)
+
+    assert historical in captured["manifest"].sources
+    assert "concept-a" in captured["manifest"].wiki_articles
+
+
+def test_compile_repair_only_persists_without_provider_for_hash_repairs(
+    monkeypatch, test_config
+):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    concepts_dir = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+    )
+    concepts_dir.mkdir(parents=True)
+    concept_path = concepts_dir / "concept-a.md"
+    concept_path.write_text(
+        f"---\nsources:\n  - {source.source_url}\n---\n\n# Concept A\n",
+        encoding="utf-8",
+    )
+    now = datetime.now(UTC)
+    write_manifest(
+        test_config.vault_path,
+        Manifest(
+            sources={
+                source.source_url: ManifestSource(
+                    content_hash=source.content_hash,
+                    saved_at=now,
+                    wiki_articles=["concept-a"],
+                )
+            },
+            wiki_articles={
+                "concept-a": ManifestWikiEntry(
+                    last_updated=now,
+                    source_urls=[source.source_url],
+                    content_hash="stale",
+                )
+            },
+        ),
+    )
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(
+        compile_cmd,
+        "get_provider",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("provider not needed")),
+    )
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+
+    compile_cmd.compile(full=False, dry_run=False, verbose=False)
+
+    repaired = read_manifest(test_config.vault_path)
+    assert repaired.wiki_articles["concept-a"].content_hash == content_hash(
+        concept_path.read_text(encoding="utf-8")
+    )
+    assert "manifest repair" in wiki_log_path(test_config).read_text(encoding="utf-8")
+
+
+def test_compile_membership_repair_rebuilds_index(monkeypatch, test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    concepts_dir = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+    )
+    concepts_dir.mkdir(parents=True)
+    (concepts_dir / "concept-a.md").write_text("# Concept A\n", encoding="utf-8")
+    now = datetime.now(UTC)
+    manifest = Manifest(
+        sources={
+            source.source_url: ManifestSource(
+                content_hash=source.content_hash,
+                saved_at=now,
+            )
+        }
+    )
+    rebuilt: list[set[str]] = []
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "read_manifest", lambda vault_path: manifest)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+    monkeypatch.setattr(
+        compile_cmd,
+        "_rebuild_wiki_index",
+        lambda config, repaired, provider: rebuilt.append(set(repaired.wiki_articles)),
+    )
+
+    compile_cmd.compile(full=False, dry_run=False, verbose=False)
+
+    assert rebuilt == [{"concept-a"}]
+    assert "concept-a" in read_manifest(test_config.vault_path).wiki_articles
+
+
+def test_compile_dry_run_does_not_persist_reconciliation(monkeypatch, test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    now = datetime.now(UTC)
+    manifest = Manifest(
+        sources={
+            source.source_url: ManifestSource(
+                content_hash=source.content_hash,
+                saved_at=now,
+            )
+        },
+        wiki_articles={
+            "missing-concept": ManifestWikiEntry(last_updated=now, content_hash="old")
+        },
+    )
+    write_manifest(test_config.vault_path, manifest)
+    original = (test_config.vault_path / "vault.manifest.json").read_bytes()
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+
+    compile_cmd.compile(full=False, dry_run=True, verbose=False)
+
+    assert (test_config.vault_path / "vault.manifest.json").read_bytes() == original
+    assert not wiki_log_path(test_config).exists()
 
 
 def test_compile_incremental_includes_relative_path_only_sources(monkeypatch, test_config):

--- a/tests/test_commands/test_lint.py
+++ b/tests/test_commands/test_lint.py
@@ -8,6 +8,28 @@ import typer
 from vaultmind.commands import lint as lint_cmd
 
 
+def test_lint_refuses_corrupted_manifest_without_report(fixture_vault, monkeypatch):
+    manifest_path = fixture_vault.vault_path / "vault.manifest.json"
+    manifest_path.write_text("not-json", encoding="utf-8")
+    inbox_dir = (
+        fixture_vault.vault_path
+        / fixture_vault.folders.wiki
+        / fixture_vault.folders.wiki_inbox
+    )
+    monkeypatch.setattr(lint_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(lint_cmd, "load_config", lambda: fixture_vault)
+    warnings: list[str] = []
+    monkeypatch.setattr(lint_cmd, "print_warning", warnings.append)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        lint_cmd.lint(preview=False, strict=False, verbose=False)
+
+    assert exc_info.value.exit_code == 1
+    assert "refusing to lint" in warnings[0]
+    assert not list(inbox_dir.glob("lint-*.md"))
+    assert manifest_path.read_text(encoding="utf-8") == "not-json"
+
+
 def test_lint_preview_no_write(fixture_vault, monkeypatch):
     """Test that --preview mode does not write any file."""
     inbox_dir = fixture_vault.vault_path / fixture_vault.folders.wiki / fixture_vault.folders.wiki_inbox

--- a/tests/test_core_linter.py
+++ b/tests/test_core_linter.py
@@ -16,6 +16,7 @@ from vaultmind.core.linter import (
     check_orphan_raw,
     check_sourceless_wiki,
     check_stale_index,
+    check_stale_manifest,
     check_uncompiled_raw,
     extract_wikilinks,
     lint_vault,
@@ -431,6 +432,34 @@ def test_check_stale_index_no_issues():
     findings = check_stale_index(index_text, concept_slugs)
 
     assert len(findings) == 0
+
+
+# ---- Tests for stale manifest state ----
+
+
+def test_check_stale_manifest_is_deterministic(sample_concept_page):
+    now = datetime.now(UTC)
+    cited_history = "https://example.com/cited-history"
+    missing_uncited = "https://example.com/missing-uncited"
+    manifest = Manifest(
+        sources={
+            cited_history: ManifestSource(content_hash="a", saved_at=now),
+            missing_uncited: ManifestSource(content_hash="b", saved_at=now),
+        },
+        wiki_articles={
+            "z-missing": ManifestWikiEntry(last_updated=now),
+            "a-missing": ManifestWikiEntry(last_updated=now),
+        },
+    )
+    concept = sample_concept_page(slug="present", sources=[cited_history])
+
+    findings = check_stale_manifest([], manifest, [concept])
+
+    assert [(finding.code, finding.subject) for finding in findings] == [
+        ("stale_manifest_concept", "a-missing"),
+        ("stale_manifest_concept", "z-missing"),
+        ("stale_manifest_source", missing_uncited),
+    ]
 
 
 # ---- Tests for check_duplicate_concepts ----

--- a/tests/test_fixture_vault.py
+++ b/tests/test_fixture_vault.py
@@ -6,11 +6,114 @@ and that using it does not mutate the source fixture files.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
-from vaultmind.core.manifest import read_manifest
+import pytest
+
+from vaultmind.core.manifest import ManifestReadError, read_manifest, reconcile_manifest
 from vaultmind.core.raw_scanner import scan_raw_sources
-from vaultmind.schemas import Manifest
+from vaultmind.schemas import Manifest, ManifestSource
+
+
+def test_missing_manifest_loads_empty_version_one(tmp_path):
+    manifest = read_manifest(tmp_path)
+    assert manifest == Manifest(version=1)
+
+
+@pytest.mark.parametrize("body", ["{bad", '{"last_compiled": "never"}'])
+def test_existing_invalid_manifest_raises_typed_error(tmp_path, body):
+    (tmp_path / "vault.manifest.json").write_text(body, encoding="utf-8")
+    with pytest.raises(ManifestReadError):
+        read_manifest(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "body",
+    ['{"version": "1"}', '{"version": true}', '{"version": 1.0}', "{}", '{"version": 2}'],
+    ids=["string", "boolean", "float", "missing", "unsupported"],
+)
+def test_persisted_manifest_requires_exact_integer_version_one(tmp_path, body):
+    (tmp_path / "vault.manifest.json").write_text(body, encoding="utf-8")
+    with pytest.raises(ManifestReadError):
+        read_manifest(tmp_path)
+
+
+def test_dangling_manifest_symlink_raises_typed_error(tmp_path):
+    path = tmp_path / "vault.manifest.json"
+    try:
+        path.symlink_to(tmp_path / "missing-manifest.json")
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ManifestReadError):
+        read_manifest(tmp_path)
+
+
+def test_readable_manifest_symlink_loads_target(tmp_path):
+    target = tmp_path / "manifest-target.json"
+    target.write_text('{"version": 1}', encoding="utf-8")
+    path = tmp_path / "vault.manifest.json"
+    try:
+        path.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    assert read_manifest(tmp_path) == Manifest(version=1)
+
+
+def test_unreadable_manifest_symlink_raises_typed_error_where_enforced(tmp_path):
+    target = tmp_path / "manifest-target.json"
+    target.write_text('{"version": 1}', encoding="utf-8")
+    path = tmp_path / "vault.manifest.json"
+    try:
+        path.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    target.chmod(0)
+    try:
+        try:
+            target.read_text(encoding="utf-8")
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("filesystem does not enforce unreadable file permissions")
+
+        with pytest.raises(ManifestReadError):
+            read_manifest(tmp_path)
+    finally:
+        target.chmod(0o600)
+
+
+def test_reconciliation_preserves_only_cited_missing_history_and_does_not_add_raw(tmp_path):
+    cited = "https://example.com/cited"
+    stale = "https://example.com/stale"
+    current_uncompiled = "https://example.com/current"
+    now = datetime.now(UTC)
+    manifest = Manifest(
+        sources={
+            cited: ManifestSource(content_hash="cited", saved_at=now),
+            stale: ManifestSource(content_hash="stale", saved_at=now),
+        }
+    )
+    concepts_dir = tmp_path / "concepts"
+    concepts_dir.mkdir()
+    (concepts_dir / "history.md").write_text(
+        f"---\nsources:\n  - {cited}\n---\n\n# History\n",
+        encoding="utf-8",
+    )
+
+    result = reconcile_manifest(
+        manifest,
+        concepts_dir=concepts_dir,
+        current_raw_keys={current_uncompiled},
+    )
+
+    assert set(result.manifest.sources) == {cited}
+    assert result.manifest.sources[cited].wiki_articles == ["history"]
+    assert current_uncompiled not in result.manifest.sources
+    assert set(result.manifest.wiki_articles) == {"history"}
 
 
 class TestFixtureVaultStructure:
@@ -98,6 +201,31 @@ class TestFixtureVaultManifest:
         entry = manifest.wiki_articles["attention-mechanisms"]
         assert len(entry.source_urls) == 1
         assert entry.source_urls[0] == "https://lena-voita.github.io/posts/annotated_transformers/attention.html"
+
+    def test_manifest_reconciles_against_representative_vault(self, fixture_vault):
+        manifest = read_manifest(fixture_vault.vault_path)
+        raw_keys = {
+            record.source_url or record.relative_path
+            for record in scan_raw_sources(fixture_vault)
+        }
+        concepts_dir = (
+            fixture_vault.vault_path
+            / fixture_vault.folders.wiki
+            / fixture_vault.folders.wiki_concepts
+        )
+
+        result = reconcile_manifest(
+            manifest,
+            concepts_dir=concepts_dir,
+            current_raw_keys=raw_keys,
+        )
+
+        source_url = "https://lena-voita.github.io/posts/annotated_transformers/attention.html"
+        assert result.manifest.version == 1
+        assert set(result.manifest.wiki_articles) == {"attention-mechanisms"}
+        assert result.manifest.sources[source_url].wiki_articles == ["attention-mechanisms"]
+        assert result.manifest.wiki_articles["attention-mechanisms"].content_hash != "1546d41d"
+        assert result.repairs == ("repaired concept hash: attention-mechanisms",)
 
 
 class TestFixtureVaultIsolation:


### PR DESCRIPTION
## Summary

- reconcile manifest wiki entries and source back-references from canonical concept files
- preserve cited historical sources while pruning missing uncited source state
- fail safely on malformed, schema-invalid, unreadable, or dangling-symlink manifests
- persist and log repair-only compile runs
- rebuild the index only when concept membership changes
- redefine `--full` as a non-destructive forced recompilation
- report stale manifest state through deterministic lint findings

## Safety

- missing manifests still initialize as version 1
- reconciliation never marks current Raw sources compiled
- dry runs report repairs without writing
- no Raw or Wiki pages are automatically deleted
- manifest schema remains version 1

## Verification

```text
uv run ruff check
uv run mypy src/vaultmind
uv run pytest
```

All checks pass; 192 tests pass.
