### PR TITLE
Prepare resilient v0.2.0 provider runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,12 @@ jobs:
 
       - name: Pytest
         run: uv run pytest
+
+      - name: Build wheel and source distribution
+        run: uv build
+
+      - name: Smoke-test installed wheel CLI
+        run: |
+          python -m venv /tmp/vaultmind-wheel-test
+          /tmp/vaultmind-wheel-test/bin/pip install dist/*.whl
+          test "$(/tmp/vaultmind-wheel-test/bin/vm version)" = "VaultMind v0.2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.2.0 - 2026-07-12
+
+### Added
+
+- Ordered runtime failover across every available provider in `fallback_chain`.
+- Sanitized provider-chain exhaustion errors and provider/model selection observability.
+- Wheel and source-distribution builds plus an isolated installed-CLI smoke test in CI.
+
+### Changed
+
+- Anthropic, OpenAI, and Ollama retry only transient connection, timeout, rate-limit, and server failures before failing over.
+- Empty AI completions trigger fallback; permanent request and credential errors fail over immediately.
+- `vm ask` and `vm compile` show concise provider errors normally while `--verbose` retains chained diagnostics.
+- Package and runtime versions are now 0.2.0.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,23 @@ uv run vm init
 
 The config stores vault paths, folder names, and AI provider preferences. The `.env` stores API keys.
 
+### Runtime provider fallback (v0.2.0)
+
+Every completion follows `ai.fallback_chain` in order. VaultMind constructs all
+configured providers that have their required credentials (Ollama requires a base
+URL), then tries them at runtime until one returns a non-empty response. A single
+configured provider uses this same chain abstraction.
+
+Each provider performs bounded retries only for transient connection, timeout,
+rate-limit, and server failures. Authentication, permission, malformed-request,
+and other permanent failures advance immediately to the next provider. Empty
+responses also advance. Cancellation and terminal interrupts are never swallowed.
+
+If the chain is exhausted, `vm ask` and `vm compile` exit non-zero with a concise,
+sanitized list of attempted provider/model pairs. Use `--verbose` for chained
+diagnostics. Structured logs record provider/model attempts and selection, but do
+not include prompts, API keys, or response bodies.
+
 ## Architecture Principles
 
 - Prefer markdown files over hidden state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vaultmind"
-version = "0.1.2"
+version = "0.2.0"
 description = "Clip anything into Obsidian. Run vm compile. Ask your living wiki."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vaultmind/__init__.py
+++ b/src/vaultmind/__init__.py
@@ -1,3 +1,3 @@
 """VaultMind — a local-first CLI for an LLM-maintained Obsidian wiki."""
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/src/vaultmind/ai/providers/__init__.py
+++ b/src/vaultmind/ai/providers/__init__.py
@@ -1,61 +1,66 @@
-"""AI provider registry."""
+"""AI provider registry and runtime fallback construction."""
 
 from __future__ import annotations
 
-__all__ = ["Provider", "get_provider"]
+__all__ = ["FallbackProvider", "Provider", "ProviderExhaustedError", "get_provider"]
 
-from vaultmind.ai.providers.base import Provider
+from vaultmind.ai.providers.base import Provider, ProviderExhaustedError
+from vaultmind.ai.providers.fallback import FallbackProvider
 from vaultmind.config import AppConfig
 
 
 def get_provider(config: AppConfig, tier: str = "fast") -> Provider:
-    """Get the appropriate AI provider based on config.
-
-    Tries providers in fallback_chain order until one is available.
-    """
+    """Build every available provider in configured runtime fallback order."""
     from vaultmind.ai.providers.anthropic import AnthropicProvider
     from vaultmind.ai.providers.ollama import OllamaProvider
     from vaultmind.ai.providers.openai import OpenAIProvider
 
-    provider_map: dict[str, type[Provider]] = {
-        "anthropic": AnthropicProvider,
-        "openai": OpenAIProvider,
-        "ollama": OllamaProvider,
-    }
-
+    providers: list[Provider] = []
     for provider_name in config.ai.fallback_chain:
-        if provider_name not in provider_map:
-            continue
-
         provider_config = config.ai.providers.get(provider_name)
         if provider_config is None:
             continue
 
-        # Check if we have the required API key
-        if provider_name == "anthropic" and not config.env.anthropic_api_key:
-            continue
-        if provider_name == "openai" and not config.env.openai_api_key:
-            continue
-
         model = getattr(provider_config.models, tier, provider_config.models.fast)
-
-        if provider_name == "ollama":
-            return OllamaProvider(
-                base_url=provider_config.base_url or config.env.ollama_base_url,
-                model=model,
-                max_tokens=config.ai.max_tokens,
+        if provider_name == "anthropic":
+            if not config.env.anthropic_api_key:
+                continue
+            providers.append(
+                AnthropicProvider(
+                    api_key=config.env.anthropic_api_key,
+                    model=model,
+                    max_tokens=config.ai.max_tokens,
+                )
+            )
+        elif provider_name == "openai":
+            if not config.env.openai_api_key:
+                continue
+            providers.append(
+                OpenAIProvider(
+                    api_key=config.env.openai_api_key,
+                    model=model,
+                    max_tokens=config.ai.max_tokens,
+                )
+            )
+        elif provider_name == "ollama":
+            base_url = provider_config.base_url or config.env.ollama_base_url
+            if not base_url.strip():
+                continue
+            providers.append(
+                OllamaProvider(
+                    base_url=base_url,
+                    model=model,
+                    max_tokens=config.ai.max_tokens,
+                )
             )
 
-        return provider_map[provider_name](
-            api_key=getattr(config.env, f"{provider_name}_api_key", ""),
-            model=model,
-            max_tokens=config.ai.max_tokens,
-        )  # type: ignore[call-arg]
+    if not providers:
+        from vaultmind.utils.display import print_error
 
-    from vaultmind.utils.display import print_error
+        print_error(
+            "No AI provider available.\n"
+            "Configure a provider and its required credentials in config.yaml and .env."
+        )
+        raise SystemExit(1)
 
-    print_error(
-        "No AI provider available.\n"
-        "Set ANTHROPIC_API_KEY in your .env file and configure a provider in config.yaml."
-    )
-    raise SystemExit(1)
+    return FallbackProvider(providers)

--- a/src/vaultmind/ai/providers/anthropic.py
+++ b/src/vaultmind/ai/providers/anthropic.py
@@ -4,27 +4,62 @@ from __future__ import annotations
 
 import anthropic
 import structlog
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from vaultmind.ai.providers.base import TRANSIENT_FAILURES, FailureKind
 
 log = structlog.get_logger()
+
+
+def classify_anthropic_failure(exc: Exception) -> FailureKind:
+    """Map Anthropic SDK failures to safe retry/failover categories."""
+    if isinstance(exc, anthropic.APITimeoutError):
+        return FailureKind.TIMEOUT
+    if isinstance(exc, anthropic.APIConnectionError):
+        return FailureKind.CONNECTION
+    if isinstance(exc, anthropic.RateLimitError):
+        return FailureKind.RATE_LIMIT
+    if isinstance(exc, anthropic.AuthenticationError):
+        return FailureKind.AUTHENTICATION
+    if isinstance(exc, anthropic.PermissionDeniedError):
+        return FailureKind.PERMISSION
+    if isinstance(exc, anthropic.APIStatusError):
+        if exc.status_code == 408:
+            return FailureKind.TIMEOUT
+        return FailureKind.SERVER if exc.status_code >= 500 else FailureKind.REQUEST
+    return FailureKind.UNEXPECTED
+
+
+def is_retryable_anthropic_failure(exc: BaseException) -> bool:
+    """Retry only transient Anthropic SDK failures."""
+    return isinstance(exc, Exception) and classify_anthropic_failure(exc) in TRANSIENT_FAILURES
 
 
 class AnthropicProvider:
     """Anthropic Claude provider using the official SDK."""
 
+    name = "anthropic"
+
     def __init__(self, api_key: str, model: str, max_tokens: int = 2000) -> None:
         self.model = model
         self.max_tokens = max_tokens
-        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        self._client = anthropic.AsyncAnthropic(api_key=api_key, max_retries=0)
+
+    classify_failure = staticmethod(classify_anthropic_failure)
+
+    @staticmethod
+    def is_retryable_failure(exc: Exception) -> bool:
+        return is_retryable_anthropic_failure(exc)
 
     @retry(
+        retry=retry_if_exception(is_retryable_anthropic_failure),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=30),
         reraise=True,
     )
     async def complete(self, prompt: str, system: str = "") -> str:
         """Send a prompt to Claude and return the completion text."""
-        log.info("anthropic_request", model=self.model)
+        log.info("anthropic_request", provider=self.name, model=self.model)
 
         message = await self._client.messages.create(
             model=self.model,
@@ -36,6 +71,7 @@ class AnthropicProvider:
         text = message.content[0].text  # type: ignore[union-attr]
         log.info(
             "anthropic_response",
+            provider=self.name,
             model=self.model,
             input_tokens=message.usage.input_tokens,
             output_tokens=message.usage.output_tokens,

--- a/src/vaultmind/ai/providers/base.py
+++ b/src/vaultmind/ai/providers/base.py
@@ -1,19 +1,153 @@
-"""Provider protocol — the abstract interface all AI providers implement."""
+"""Typed contracts shared by VaultMind AI providers."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Protocol
 
 
-class Provider(Protocol):
-    """Abstract interface for AI providers.
+class FailureKind(StrEnum):
+    """Safe, provider-independent failure classifications."""
 
-    ~100 lines of abstraction instead of LiteLLM's 100+ provider support.
-    We only need what we use.
-    """
+    CONNECTION = "connection failure"
+    TIMEOUT = "request timed out"
+    RATE_LIMIT = "rate limited"
+    SERVER = "provider server failure"
+    AUTHENTICATION = "authentication failed"
+    PERMISSION = "permission denied"
+    REQUEST = "invalid request"
+    EMPTY_RESPONSE = "empty response"
+    UNEXPECTED = "unexpected provider error"
 
+
+TRANSIENT_FAILURES = frozenset(
+    {FailureKind.CONNECTION, FailureKind.TIMEOUT, FailureKind.RATE_LIMIT, FailureKind.SERVER}
+)
+
+MAX_IDENTITY_LENGTH = 80
+MAX_ATTEMPT_REASON_LENGTH = 80
+MAX_RETAINED_ATTEMPTS = 8
+MAX_OMITTED_ATTEMPTS = 999_999_999
+MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH = 2_048
+
+
+class ProviderFailureClassifier(Protocol):
+    """Interface used by retry policies and the runtime fallback chain."""
+
+    def classify_failure(self, exc: Exception) -> FailureKind:
+        """Classify an exception without exposing its potentially sensitive text."""
+        ...
+
+    def is_retryable_failure(self, exc: Exception) -> bool:
+        """Return whether an individual provider may retry this failure."""
+        ...
+
+
+class Provider(ProviderFailureClassifier, Protocol):
+    """Abstract interface implemented by every AI provider."""
+
+    name: str
     model: str
 
     async def complete(self, prompt: str, system: str = "") -> str:
         """Send a prompt and return the completion text."""
         ...
+
+
+class ProviderError(Exception):
+    """Base class for typed provider-layer failures."""
+
+
+class EmptyProviderResponseError(ProviderError):
+    """A provider returned no usable completion text."""
+
+
+def _safe_text(value: object, *, fallback: str, limit: int) -> str:
+    """Return bounded single-line text without retaining the original value."""
+    text = "" if value is None else " ".join(str(value).split())[:limit]
+    return text or fallback
+
+
+def safe_identity(value: object, *, fallback: str) -> str:
+    """Return a bounded single-line identity suitable for logs and errors."""
+    return _safe_text(value, fallback=fallback, limit=MAX_IDENTITY_LENGTH)
+
+
+@dataclass(frozen=True)
+class ProviderAttempt:
+    """A sanitized record of one provider/model attempted by a chain."""
+
+    provider: str
+    model: str
+    reason: FailureKind
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provider", safe_identity(self.provider, fallback="unknown"))
+        object.__setattr__(self, "model", safe_identity(self.model, fallback="unknown"))
+        if not isinstance(self.reason, FailureKind):
+            object.__setattr__(self, "reason", FailureKind.UNEXPECTED)
+
+    def render(self) -> str:
+        reason = _safe_text(
+            self.reason.value,
+            fallback=FailureKind.UNEXPECTED.value,
+            limit=MAX_ATTEMPT_REASON_LENGTH,
+        )
+        return f"{self.provider}/{self.model}: {reason}"
+
+
+def _bounded_omission_count(value: object, additional: int) -> tuple[int, bool]:
+    """Return a safe count and whether it is only a lower bound."""
+    supplied = int(value) if isinstance(value, int) and not isinstance(value, bool) and value > 0 else 0
+    if additional >= MAX_OMITTED_ATTEMPTS:
+        return MAX_OMITTED_ATTEMPTS, additional > MAX_OMITTED_ATTEMPTS or supplied > 0
+    if supplied > MAX_OMITTED_ATTEMPTS - additional:
+        return MAX_OMITTED_ATTEMPTS, True
+    return supplied + additional, False
+
+
+def _render_exhausted_message(details: str, omission: str) -> str:
+    """Render an exhaustion message with a hard final bound."""
+    prefix = "AI provider chain exhausted"
+    if omission:
+        omission_only = f"{prefix}: {omission}"
+        detail_limit = MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH - len(omission_only) - 2
+        bounded_details = details[: max(0, detail_limit)].rstrip()
+        message = (
+            f"{prefix}: {bounded_details}; {omission}" if bounded_details else omission_only
+        )
+    elif details:
+        message = f"{prefix}: {details}"
+    else:
+        message = prefix
+
+    # Do not rely on the bounds of individual fields: this constructor is public
+    # and the final rendered exception must remain bounded under all inputs.
+    return message[:MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH]
+
+
+class ProviderExhaustedError(ProviderError):
+    """Every configured provider failed for one completion request."""
+
+    def __init__(
+        self,
+        attempts: tuple[ProviderAttempt, ...],
+        *,
+        omitted_attempts: int = 0,
+    ) -> None:
+        retained = attempts[:MAX_RETAINED_ATTEMPTS]
+        self.attempts = retained
+        additional = len(attempts) - len(retained)
+        self.omitted_attempts, is_lower_bound = _bounded_omission_count(
+            omitted_attempts, additional
+        )
+
+        details = "; ".join(attempt.render() for attempt in retained)
+        qualifier = "at least " if is_lower_bound else ""
+        omission = (
+            f"... {qualifier}{self.omitted_attempts} attempts omitted"
+            if self.omitted_attempts
+            else ""
+        )
+        super().__init__(_render_exhausted_message(details, omission))

--- a/src/vaultmind/ai/providers/fallback.py
+++ b/src/vaultmind/ai/providers/fallback.py
@@ -1,0 +1,98 @@
+"""Ordered runtime failover across configured AI providers."""
+
+from __future__ import annotations
+
+import structlog
+
+from vaultmind.ai.providers.base import (
+    MAX_RETAINED_ATTEMPTS,
+    TRANSIENT_FAILURES,
+    EmptyProviderResponseError,
+    FailureKind,
+    Provider,
+    ProviderAttempt,
+    ProviderExhaustedError,
+    safe_identity,
+)
+
+log = structlog.get_logger()
+
+
+class FallbackProvider:
+    """Try providers in configuration order for every completion request."""
+
+    name = "fallback"
+
+    def __init__(self, providers: list[Provider]) -> None:
+        if not providers:
+            raise ValueError("FallbackProvider requires at least one provider")
+        self.providers = tuple(providers)
+        # Retain the old registry's useful model attribute for callers and tests.
+        self.model = self.providers[0].model
+        self.selected_provider: str | None = None
+        self.selected_model: str | None = None
+
+    @staticmethod
+    def classify_failure(exc: Exception) -> FailureKind:
+        if isinstance(exc, EmptyProviderResponseError):
+            return FailureKind.EMPTY_RESPONSE
+        return FailureKind.UNEXPECTED
+
+    @staticmethod
+    def is_retryable_failure(exc: Exception) -> bool:
+        return FallbackProvider.classify_failure(exc) in TRANSIENT_FAILURES
+
+    async def complete(self, prompt: str, system: str = "") -> str:
+        """Return the first usable response, or raise a sanitized aggregate."""
+        attempts: list[ProviderAttempt] = []
+        omitted_attempts = 0
+        self.selected_provider = None
+        self.selected_model = None
+
+        for provider in self.providers:
+            provider_name = safe_identity(getattr(provider, "name", None), fallback="unknown")
+            model = safe_identity(provider.model, fallback="unknown")
+            log.info("provider_attempt", provider=provider_name, model=model)
+            try:
+                response = await provider.complete(prompt, system=system)
+                if not response.strip():
+                    raise EmptyProviderResponseError()
+            except Exception as exc:
+                # CancelledError, KeyboardInterrupt, and SystemExit inherit from
+                # BaseException and intentionally bypass this handler.
+                classifier = getattr(provider, "classify_failure", None)
+                classified = (
+                    FailureKind.EMPTY_RESPONSE
+                    if isinstance(exc, EmptyProviderResponseError)
+                    else classifier(exc)
+                    if callable(classifier)
+                    else self.classify_failure(exc)
+                )
+                reason = (
+                    classified if isinstance(classified, FailureKind) else FailureKind.UNEXPECTED
+                )
+                attempt = ProviderAttempt(provider_name, model, reason)
+                if len(attempts) < MAX_RETAINED_ATTEMPTS:
+                    attempts.append(attempt)
+                else:
+                    omitted_attempts += 1
+                log.warning(
+                    "provider_failed",
+                    provider=attempt.provider,
+                    model=attempt.model,
+                    failure_kind=attempt.reason.value,
+                    retryable=attempt.reason in TRANSIENT_FAILURES,
+                )
+                continue
+
+            self.selected_provider = provider_name
+            self.selected_model = model
+            log.info("provider_selected", provider=provider_name, model=model)
+            return response
+
+        exhausted = ProviderExhaustedError(
+            tuple(attempts), omitted_attempts=omitted_attempts
+        )
+        # Raw SDK exceptions can contain credentials, response bodies, or prompt
+        # content. Do not expose the final one through normal exception chaining.
+        raise exhausted from None

--- a/src/vaultmind/ai/providers/ollama.py
+++ b/src/vaultmind/ai/providers/ollama.py
@@ -6,17 +6,42 @@ from typing import Any
 
 import httpx
 import structlog
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from vaultmind.ai.providers.base import TRANSIENT_FAILURES, FailureKind
 
 log = structlog.get_logger()
 
 
-class OllamaProvider:
-    """Local Ollama provider.
+def classify_ollama_failure(exc: Exception) -> FailureKind:
+    """Distinguish retryable transport/server failures from permanent HTTP errors."""
+    if isinstance(exc, httpx.TimeoutException):
+        return FailureKind.TIMEOUT
+    if isinstance(exc, httpx.TransportError):
+        return FailureKind.CONNECTION
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        if status == 401:
+            return FailureKind.AUTHENTICATION
+        if status == 403:
+            return FailureKind.PERMISSION
+        if status == 408:
+            return FailureKind.TIMEOUT
+        if status == 429:
+            return FailureKind.RATE_LIMIT
+        return FailureKind.SERVER if status >= 500 else FailureKind.REQUEST
+    return FailureKind.UNEXPECTED
 
-    Uses Ollama's native `/api/chat` endpoint rather than an OpenAI-compatible
-    shim, so local mode works without an API key.
-    """
+
+def is_retryable_ollama_failure(exc: BaseException) -> bool:
+    """Retry only transient Ollama transport, rate-limit, and server failures."""
+    return isinstance(exc, Exception) and classify_ollama_failure(exc) in TRANSIENT_FAILURES
+
+
+class OllamaProvider:
+    """Local Ollama provider using its native ``/api/chat`` endpoint."""
+
+    name = "ollama"
 
     def __init__(
         self,
@@ -31,14 +56,21 @@ class OllamaProvider:
         self.max_tokens = max_tokens
         self._transport = transport
 
+    classify_failure = staticmethod(classify_ollama_failure)
+
+    @staticmethod
+    def is_retryable_failure(exc: Exception) -> bool:
+        return is_retryable_ollama_failure(exc)
+
     @retry(
+        retry=retry_if_exception(is_retryable_ollama_failure),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=30),
         reraise=True,
     )
     async def complete(self, prompt: str, system: str = "") -> str:
         """Send a prompt to Ollama and return the completion text."""
-        log.info("ollama_request", model=self.model, base_url=self.base_url)
+        log.info("ollama_request", provider=self.name, model=self.model)
 
         messages: list[dict[str, str]] = []
         if system:
@@ -64,7 +96,7 @@ class OllamaProvider:
         if isinstance(message, dict):
             content = message.get("content")
             if isinstance(content, str):
-                log.info("ollama_response", model=self.model)
+                log.info("ollama_response", provider=self.name, model=self.model)
                 return content
 
         fallback = data.get("response")

--- a/src/vaultmind/ai/providers/openai.py
+++ b/src/vaultmind/ai/providers/openai.py
@@ -2,29 +2,65 @@
 
 from __future__ import annotations
 
+import openai
 import structlog
 from openai import AsyncOpenAI
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from vaultmind.ai.providers.base import TRANSIENT_FAILURES, FailureKind
 
 log = structlog.get_logger()
+
+
+def classify_openai_failure(exc: Exception) -> FailureKind:
+    """Map OpenAI SDK failures to safe retry/failover categories."""
+    if isinstance(exc, openai.APITimeoutError):
+        return FailureKind.TIMEOUT
+    if isinstance(exc, openai.APIConnectionError):
+        return FailureKind.CONNECTION
+    if isinstance(exc, openai.RateLimitError):
+        return FailureKind.RATE_LIMIT
+    if isinstance(exc, openai.AuthenticationError):
+        return FailureKind.AUTHENTICATION
+    if isinstance(exc, openai.PermissionDeniedError):
+        return FailureKind.PERMISSION
+    if isinstance(exc, openai.APIStatusError):
+        if exc.status_code == 408:
+            return FailureKind.TIMEOUT
+        return FailureKind.SERVER if exc.status_code >= 500 else FailureKind.REQUEST
+    return FailureKind.UNEXPECTED
+
+
+def is_retryable_openai_failure(exc: BaseException) -> bool:
+    """Retry only transient OpenAI SDK failures."""
+    return isinstance(exc, Exception) and classify_openai_failure(exc) in TRANSIENT_FAILURES
 
 
 class OpenAIProvider:
     """OpenAI GPT provider using the official SDK."""
 
+    name = "openai"
+
     def __init__(self, api_key: str, model: str, max_tokens: int = 2000) -> None:
         self.model = model
         self.max_tokens = max_tokens
-        self._client = AsyncOpenAI(api_key=api_key)
+        self._client = AsyncOpenAI(api_key=api_key, max_retries=0)
+
+    classify_failure = staticmethod(classify_openai_failure)
+
+    @staticmethod
+    def is_retryable_failure(exc: Exception) -> bool:
+        return is_retryable_openai_failure(exc)
 
     @retry(
+        retry=retry_if_exception(is_retryable_openai_failure),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=30),
         reraise=True,
     )
     async def complete(self, prompt: str, system: str = "") -> str:
         """Send a prompt to OpenAI and return the completion text."""
-        log.info("openai_request", model=self.model)
+        log.info("openai_request", provider=self.name, model=self.model)
 
         response = await self._client.chat.completions.create(
             model=self.model,
@@ -38,6 +74,7 @@ class OpenAIProvider:
         text = response.choices[0].message.content or ""
         log.info(
             "openai_response",
+            provider=self.name,
             model=self.model,
             total_tokens=response.usage.total_tokens if response.usage else 0,
         )

--- a/src/vaultmind/commands/ask.py
+++ b/src/vaultmind/commands/ask.py
@@ -7,10 +7,10 @@ import asyncio
 import typer
 
 from vaultmind.ai.asker import ask_question
-from vaultmind.ai.providers import get_provider
+from vaultmind.ai.providers import ProviderExhaustedError, get_provider
 from vaultmind.config import load_config
 from vaultmind.core.wiki_log import append_wiki_log
-from vaultmind.utils.display import console, print_info
+from vaultmind.utils.display import console, print_error, print_info
 from vaultmind.utils.logging import setup_logging
 
 
@@ -37,19 +37,25 @@ def ask(
 
     provider = get_provider(config, tier="deep")
 
-    result = asyncio.run(
-        ask_question(
-            question=question,
-            provider=provider,
-            vault_path=config.vault_path,
-            folders_wiki=config.folders.wiki,
-            folders_wiki_concepts=config.folders.wiki_concepts,
-            folders_wiki_queries=config.folders.wiki_queries,
-            folders_raw=config.folders.raw,
-            depth=depth,
-            file_answer=not preview,
+    try:
+        result = asyncio.run(
+            ask_question(
+                question=question,
+                provider=provider,
+                vault_path=config.vault_path,
+                folders_wiki=config.folders.wiki,
+                folders_wiki_concepts=config.folders.wiki_concepts,
+                folders_wiki_queries=config.folders.wiki_queries,
+                folders_raw=config.folders.raw,
+                depth=depth,
+                file_answer=not preview,
+            )
         )
-    )
+    except ProviderExhaustedError as exc:
+        print_error(str(exc))
+        if verbose:
+            raise
+        raise typer.Exit(1) from None
 
     if preview:
         console.print(result.answer)

--- a/src/vaultmind/commands/compile.py
+++ b/src/vaultmind/commands/compile.py
@@ -19,7 +19,7 @@ import typer
 import yaml
 
 from vaultmind.ai.compiler import CompileResult, compile_sources, rebuild_index
-from vaultmind.ai.providers import Provider, get_provider
+from vaultmind.ai.providers import Provider, ProviderExhaustedError, get_provider
 from vaultmind.config import AppConfig, load_config
 from vaultmind.core.manifest import (
     ManifestReadError,
@@ -36,7 +36,7 @@ from vaultmind.core.raw_scanner import RawSourceRecord, scan_raw_sources
 from vaultmind.core.wiki_log import append_wiki_log
 from vaultmind.core.writer import write_markdown_page
 from vaultmind.schemas import Manifest, ManifestSource
-from vaultmind.utils.display import print_info, print_success, print_warning
+from vaultmind.utils.display import print_error, print_info, print_success, print_warning
 from vaultmind.utils.hashing import content_hash
 from vaultmind.utils.logging import setup_logging
 
@@ -103,11 +103,18 @@ def compile(
         callback=_validate_max_touches,
     ),
 ) -> None:
-    """Compile source notes into wiki concept articles.
+    """Compile source notes into wiki concept articles."""
+    try:
+        _compile(full=full, dry_run=dry_run, verbose=verbose, max_touches=max_touches)
+    except ProviderExhaustedError as exc:
+        print_error(str(exc))
+        if verbose:
+            raise
+        raise typer.Exit(1) from None
 
-    Run without flags for incremental compilation (only new/changed sources).
-    Use --full to recompile everything.
-    """
+
+def _compile(*, full: bool, dry_run: bool, verbose: bool, max_touches: int) -> None:
+    """Implement compile while the CLI boundary handles provider exhaustion."""
     setup_logging(verbose=verbose)
     config = load_config()
 

--- a/tests/test_commands/test_ask.py
+++ b/tests/test_commands/test_ask.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
 from typer.testing import CliRunner
 
 from vaultmind.ai.asker import AskResult
+from vaultmind.ai.providers.base import FailureKind, ProviderAttempt, ProviderExhaustedError
 from vaultmind.commands import ask as ask_cmd
 from vaultmind.main import app
 
@@ -43,3 +45,54 @@ def test_ask_preview_is_strictly_no_write(monkeypatch, test_config):
     assert not query_dir.exists()
     assert not (query_dir / "preview-question.md").exists()
     assert wiki_log.read_text(encoding="utf-8") == original_log
+
+
+def _exhausted_error() -> ProviderExhaustedError:
+    return ProviderExhaustedError(
+        (ProviderAttempt("anthropic", "claude", FailureKind.AUTHENTICATION),)
+    )
+
+
+@pytest.mark.parametrize("preview", [False, True])
+def test_ask_provider_exhaustion_is_concise_and_nonzero(
+    monkeypatch, test_config, preview
+):
+    async def fail_ask(**kwargs):
+        del kwargs
+        raise _exhausted_error() from RuntimeError("diagnostic secret")
+
+    monkeypatch.setattr(ask_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(ask_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(ask_cmd, "get_provider", lambda config, tier: object())
+    monkeypatch.setattr(ask_cmd, "ask_question", fail_ask)
+
+    args = ["ask", "private question"]
+    if preview:
+        args.append("--preview")
+    result = CliRunner().invoke(app, args)
+
+    assert result.exit_code == 1
+    assert "AI provider chain exhausted" in result.output
+    assert "anthropic/claude: authentication failed" in result.output
+    assert "diagnostic secret" not in result.output
+    assert "private question" not in result.output
+    assert "Traceback" not in result.output
+
+
+def test_ask_verbose_preserves_provider_exception_chain(monkeypatch, test_config):
+    cause = RuntimeError("diagnostic detail")
+
+    async def fail_ask(**kwargs):
+        del kwargs
+        raise _exhausted_error() from cause
+
+    monkeypatch.setattr(ask_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(ask_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(ask_cmd, "get_provider", lambda config, tier: object())
+    monkeypatch.setattr(ask_cmd, "ask_question", fail_ask)
+
+    result = CliRunner().invoke(app, ["ask", "question", "--verbose"])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ProviderExhaustedError)
+    assert result.exception.__cause__ is cause

--- a/tests/test_commands/test_compile.py
+++ b/tests/test_commands/test_compile.py
@@ -10,12 +10,20 @@ from pathlib import Path
 import pytest
 import typer
 
+from vaultmind.ai.providers.base import FailureKind, ProviderAttempt, ProviderExhaustedError
+from vaultmind.ai.providers.fallback import FallbackProvider
 from vaultmind.commands import compile as compile_cmd
 from vaultmind.core.manifest import read_manifest, write_manifest
 from vaultmind.core.raw_scanner import RawSourceRecord
 from vaultmind.core.wiki_log import wiki_log_path
 from vaultmind.schemas import Manifest, ManifestSource, ManifestWikiEntry
 from vaultmind.utils.hashing import content_hash
+
+
+def _provider_exhausted() -> ProviderExhaustedError:
+    return ProviderExhaustedError(
+        (ProviderAttempt("openai", "gpt", FailureKind.SERVER),)
+    )
 
 
 def _raw_source(
@@ -1017,3 +1025,86 @@ def test_run_compile_async_propagation_failure_preserves_retry_hash_and_backlink
     assert compile_cmd.get_changed_sources(
         manifest, {source.source_url: source.content_hash}
     ) == [source.source_url]
+
+
+def test_compile_provider_exhaustion_is_concise_normally(monkeypatch):
+    errors: list[str] = []
+
+    def fail_compile(**kwargs):
+        del kwargs
+        raise _provider_exhausted() from RuntimeError("diagnostic secret")
+
+    monkeypatch.setattr(compile_cmd, "_compile", fail_compile)
+    monkeypatch.setattr(compile_cmd, "print_error", errors.append)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        compile_cmd.compile(full=False, dry_run=False, verbose=False, max_touches=5)
+
+    assert exc_info.value.exit_code == 1
+    assert errors == ["AI provider chain exhausted: openai/gpt: provider server failure"]
+    assert "diagnostic secret" not in errors[0]
+
+
+def test_compile_verbose_preserves_provider_exception_chain(monkeypatch):
+    cause = RuntimeError("diagnostic detail")
+
+    def fail_compile(**kwargs):
+        del kwargs
+        raise _provider_exhausted() from cause
+
+    monkeypatch.setattr(compile_cmd, "_compile", fail_compile)
+    monkeypatch.setattr(compile_cmd, "print_error", lambda message: None)
+
+    with pytest.raises(ProviderExhaustedError) as exc_info:
+        compile_cmd.compile(full=False, dry_run=False, verbose=True, max_touches=5)
+
+    assert exc_info.value.__cause__ is cause
+
+
+def test_index_rebuild_propagates_provider_exhaustion_without_writing(test_config):
+    class FailingProvider:
+        name = "ollama"
+        model = "local-model"
+
+        @staticmethod
+        def classify_failure(exc: Exception) -> FailureKind:
+            del exc
+            return FailureKind.CONNECTION
+
+        @staticmethod
+        def is_retryable_failure(exc: Exception) -> bool:
+            del exc
+            return True
+
+        async def complete(self, prompt: str, system: str = "") -> str:
+            del prompt, system
+            raise ConnectionError("private endpoint")
+
+    concepts_dir = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+    )
+    concepts_dir.mkdir(parents=True)
+    article = concepts_dir / "concept-a.md"
+    article.write_text("# Concept A\n", encoding="utf-8")
+    manifest = Manifest(
+        wiki_articles={
+            "concept-a": ManifestWikiEntry(
+                last_updated=datetime.now(UTC),
+                content_hash=content_hash(article.read_text(encoding="utf-8")),
+            )
+        }
+    )
+
+    with pytest.raises(ProviderExhaustedError):
+        compile_cmd._rebuild_wiki_index(
+            test_config, manifest, FallbackProvider([FailingProvider()])
+        )
+
+    index_path = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / f"{test_config.folders.wiki_index}.md"
+    )
+    assert not index_path.exists()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,27 @@
+"""Release artifact and version contract tests."""
+
+from __future__ import annotations
+
+import tomllib
+from importlib.metadata import version
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from vaultmind import __version__
+from vaultmind.main import app
+
+
+def test_package_and_runtime_versions_are_consistent() -> None:
+    project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+
+    assert project["version"] == "0.2.0"
+    assert __version__ == "0.2.0"
+    assert version("vaultmind") == "0.2.0"
+
+
+def test_vm_version_reports_release_version() -> None:
+    result = CliRunner().invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "VaultMind v0.2.0"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,11 +1,29 @@
 """Tests for AI providers."""
 
 import asyncio
+import traceback
 
 import httpx
+import pytest
 
-from vaultmind.ai.providers import get_provider
-from vaultmind.ai.providers.ollama import OllamaProvider
+from vaultmind.ai.providers import FallbackProvider, get_provider
+from vaultmind.ai.providers.anthropic import (
+    classify_anthropic_failure,
+    is_retryable_anthropic_failure,
+)
+from vaultmind.ai.providers.base import (
+    MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH,
+    MAX_IDENTITY_LENGTH,
+    MAX_RETAINED_ATTEMPTS,
+    FailureKind,
+    ProviderExhaustedError,
+)
+from vaultmind.ai.providers.ollama import (
+    OllamaProvider,
+    classify_ollama_failure,
+    is_retryable_ollama_failure,
+)
+from vaultmind.ai.providers.openai import classify_openai_failure, is_retryable_openai_failure
 from vaultmind.config import AIConfig, AppConfig, EnvSettings, ProviderConfig, ProviderModels
 
 
@@ -37,7 +55,8 @@ def test_get_ollama_provider_without_api_key(tmp_vault):
 
     provider = get_provider(config, tier="deep")
 
-    assert isinstance(provider, OllamaProvider)
+    assert isinstance(provider, FallbackProvider)
+    assert isinstance(provider.providers[0], OllamaProvider)
     assert provider.model == "llama3:70b"
 
 
@@ -58,3 +77,248 @@ def test_ollama_provider_complete_uses_native_chat_endpoint():
     result = asyncio.run(provider.complete("hello", system="system"))
 
     assert result == "local answer"
+
+
+class _StubProvider:
+    def __init__(
+        self,
+        name: str,
+        model: str,
+        outcomes: list[str | BaseException],
+        kind: FailureKind = FailureKind.REQUEST,
+    ) -> None:
+        self.name = name
+        self.model = model
+        self.outcomes = outcomes
+        self.kind = kind
+        self.calls = 0
+
+    def classify_failure(self, exc: Exception) -> FailureKind:
+        del exc
+        return self.kind
+
+    def is_retryable_failure(self, exc: Exception) -> bool:
+        del exc
+        return self.kind in {
+            FailureKind.CONNECTION,
+            FailureKind.TIMEOUT,
+            FailureKind.RATE_LIMIT,
+            FailureKind.SERVER,
+        }
+
+    async def complete(self, prompt: str, system: str = "") -> str:
+        del prompt, system
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def test_runtime_fallback_is_ordered_and_returns_success_unchanged():
+    first = _StubProvider("first", "fast-a", [RuntimeError("permanent")])
+    second = _StubProvider("second", "fast-b", ["  exact response  "])
+    third = _StubProvider("third", "fast-c", ["unused"])
+    provider = FallbackProvider([first, second, third])
+
+    result = asyncio.run(provider.complete("secret prompt"))
+
+    assert result == "  exact response  "
+    assert [first.calls, second.calls, third.calls] == [1, 1, 0]
+    assert provider.selected_provider == "second"
+    assert provider.selected_model == "fast-b"
+
+
+def test_empty_completion_advances_to_next_provider():
+    first = _StubProvider("first", "a", [" \n\t"])
+    second = _StubProvider("second", "b", ["answer"])
+    provider = FallbackProvider([first, second])
+
+    assert asyncio.run(provider.complete("prompt")) == "answer"
+    assert first.calls == second.calls == 1
+
+
+@pytest.mark.parametrize(
+    "terminal",
+    [asyncio.CancelledError(), KeyboardInterrupt(), SystemExit(9)],
+)
+def test_terminal_exceptions_are_never_swallowed(terminal):
+    first = _StubProvider("first", "a", [terminal])
+    second = _StubProvider("second", "b", ["must not run"])
+
+    with pytest.raises(type(terminal)):
+        asyncio.run(FallbackProvider([first, second]).complete("prompt"))
+
+    assert second.calls == 0
+
+
+def test_exhaustion_is_typed_ordered_and_sanitized():
+    secret = "sk-secret-value"
+    prompt = "private prompt contents"
+    first = _StubProvider("first", "model-a", [RuntimeError(secret)])
+    second = _StubProvider("second", "model-b", [ValueError(prompt)])
+
+    with pytest.raises(ProviderExhaustedError) as exc_info:
+        asyncio.run(FallbackProvider([first, second]).complete(prompt))
+
+    error = exc_info.value
+    assert [(a.provider, a.model) for a in error.attempts] == [
+        ("first", "model-a"),
+        ("second", "model-b"),
+    ]
+    assert error.omitted_attempts == 0
+    assert secret not in str(error)
+    assert prompt not in str(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert error.__suppress_context__
+    assert secret not in "".join(traceback.format_exception(error))
+    assert len(str(error)) <= MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH
+
+
+@pytest.mark.parametrize("omitted_attempts", [-1, True, False, "12", 1.5, None])
+def test_exhaustion_defensively_rejects_invalid_omitted_counts(omitted_attempts):
+    error = ProviderExhaustedError((), omitted_attempts=omitted_attempts)  # type: ignore[arg-type]
+
+    assert error.omitted_attempts == 0
+    assert "attempts omitted" not in str(error)
+    assert len(str(error)) <= MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH
+
+
+def test_exhaustion_bounds_pathologically_large_omitted_count():
+    error = ProviderExhaustedError((), omitted_attempts=10**3000)
+    message = str(error)
+
+    assert 0 < error.omitted_attempts < 10**3000
+    assert f"at least {error.omitted_attempts} attempts omitted" in message
+    assert len(message) <= MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH
+
+
+def test_large_exhaustion_retains_bounded_ordered_attempts_and_reports_omissions():
+    provider_count = 1_000
+    providers = [
+        _StubProvider(
+            f"provider-{index}-" + "p" * 100,
+            f"model-{index}-" + "m" * 100,
+            [RuntimeError(f"secret-{index}")],
+        )
+        for index in range(provider_count)
+    ]
+
+    with pytest.raises(ProviderExhaustedError) as exc_info:
+        asyncio.run(FallbackProvider(providers).complete("private prompt"))
+
+    error = exc_info.value
+    message = str(error)
+    assert len(error.attempts) == MAX_RETAINED_ATTEMPTS
+    assert all(len(attempt.provider) == MAX_IDENTITY_LENGTH for attempt in error.attempts)
+    assert all(len(attempt.model) == MAX_IDENTITY_LENGTH for attempt in error.attempts)
+    assert [attempt.provider.split("-")[1] for attempt in error.attempts] == [
+        str(index) for index in range(MAX_RETAINED_ATTEMPTS)
+    ]
+    assert error.omitted_attempts == provider_count - MAX_RETAINED_ATTEMPTS
+    assert message.endswith(f"{error.omitted_attempts} attempts omitted")
+    assert len(message) <= MAX_EXHAUSTED_ERROR_MESSAGE_LENGTH
+    assert "secret-999" not in message
+    assert "private prompt" not in message
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert error.__suppress_context__
+
+
+@pytest.mark.parametrize(
+    ("status", "kind"),
+    [(401, FailureKind.AUTHENTICATION), (403, FailureKind.PERMISSION)],
+)
+def test_ollama_auth_http_failures_do_not_retry_and_use_safe_aggregate_labels(status, kind):
+    calls = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status, text="secret response body", request=request)
+
+    provider = OllamaProvider(
+        base_url="http://ollama.test",
+        model="local-model",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(ProviderExhaustedError) as exc_info:
+        asyncio.run(FallbackProvider([provider]).complete("private prompt"))
+
+    assert calls == 1
+    assert exc_info.value.attempts[0].reason is kind
+    assert kind.value in str(exc_info.value)
+    assert "secret response body" not in str(exc_info.value)
+    assert "private prompt" not in str(exc_info.value)
+
+
+def test_sdk_failure_classification_retries_only_transient_errors():
+    request = httpx.Request("POST", "https://provider.test")
+    server_response = httpx.Response(503, request=request)
+    client_response = httpx.Response(400, request=request)
+    server = httpx.HTTPStatusError("contains secret", request=request, response=server_response)
+    client = httpx.HTTPStatusError("contains secret", request=request, response=client_response)
+
+    assert classify_ollama_failure(httpx.ReadTimeout("timeout", request=request)) is FailureKind.TIMEOUT
+    assert classify_ollama_failure(server) is FailureKind.SERVER
+    assert classify_ollama_failure(client) is FailureKind.REQUEST
+    assert is_retryable_ollama_failure(server)
+    assert not is_retryable_ollama_failure(client)
+
+    import anthropic
+    import openai
+
+    anthropic_auth = anthropic.AuthenticationError(
+        "secret", response=httpx.Response(401, request=request), body=None
+    )
+    anthropic_server = anthropic.InternalServerError(
+        "secret", response=httpx.Response(503, request=request), body=None
+    )
+    openai_auth = openai.AuthenticationError(
+        "secret", response=httpx.Response(401, request=request), body=None
+    )
+    openai_server = openai.InternalServerError(
+        "secret", response=httpx.Response(503, request=request), body=None
+    )
+
+    assert classify_anthropic_failure(anthropic_auth) is FailureKind.AUTHENTICATION
+    assert classify_anthropic_failure(anthropic_server) is FailureKind.SERVER
+    assert not is_retryable_anthropic_failure(anthropic_auth)
+    assert is_retryable_anthropic_failure(anthropic_server)
+    assert classify_openai_failure(openai_auth) is FailureKind.AUTHENTICATION
+    assert classify_openai_failure(openai_server) is FailureKind.SERVER
+    assert not is_retryable_openai_failure(openai_auth)
+    assert is_retryable_openai_failure(openai_server)
+
+    # SDK-independent unexpected exceptions must never be retried.
+    assert classify_anthropic_failure(ValueError("secret")) is FailureKind.UNEXPECTED
+    assert classify_openai_failure(ValueError("secret")) is FailureKind.UNEXPECTED
+
+
+def test_registry_builds_available_providers_in_fallback_order(tmp_vault):
+    config = AppConfig(
+        vault_path=tmp_vault,
+        ai=AIConfig(
+            fallback_chain=["openai", "anthropic", "ollama"],
+            providers={
+                "openai": ProviderConfig(models=ProviderModels(fast="gpt-fast", deep="gpt-deep")),
+                "anthropic": ProviderConfig(models=ProviderModels(fast="claude-fast", deep="claude-deep")),
+                "ollama": ProviderConfig(
+                    base_url="http://ollama.test",
+                    models=ProviderModels(fast="local-fast", deep="local-deep"),
+                ),
+            },
+        ),
+        # OpenAI is deliberately excluded because its credential is absent.
+        env=EnvSettings(anthropic_api_key="configured", openai_api_key=""),
+    )
+
+    provider = get_provider(config, tier="deep")
+
+    assert isinstance(provider, FallbackProvider)
+    assert [(item.name, item.model) for item in provider.providers] == [
+        ("anthropic", "claude-deep"),
+        ("ollama", "local-deep"),
+    ]


### PR DESCRIPTION
## Summary

- add ordered runtime failover across configured Anthropic, OpenAI, and Ollama providers
- retry only transient connection, timeout, rate-limit, and server failures
- advance immediately on permanent provider errors and empty completions
- preserve cancellation and terminal exceptions
- provide typed, sanitized, strictly bounded aggregate exhaustion errors
- add concise normal-mode and diagnostic verbose CLI handling
- bump package/runtime version to 0.2.0 and add release notes
- build and smoke-test wheel/sdist artifacts in CI

## Safety and observability

- logs provider/model attempts and selected provider without prompts, keys, or response bodies
- aggregate errors retain bounded ordered reasons and omitted-attempt counts
- Ollama authentication and permission failures are classified explicitly
- Ask preview remains no-write
- compile partial-failure and propagation retry behavior is unchanged

## Verification

```text
uv run ruff check
uv run mypy src/vaultmind
uv run pytest
uv build
```

218 tests pass. Wheel and sdist build successfully; isolated wheel smoke prints `VaultMind v0.2.0`.
