### PR TITLE
Keep Dependabot updates lockfile-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "lockfile-only"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- update locked dependency versions without unnecessarily raising declared compatibility floors
- preserve the existing weekly Python dependency schedule and PR limit

The five existing minimum-floor PRs will be closed after this policy lands so Dependabot can regenerate reproducible lockfile updates.