### PR TITLE
Update artifact workflow actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
           test "$(/tmp/vaultmind-release-test/bin/vm version)" = "VaultMind v${EXPECTED_VERSION}"
 
       - name: Retain built distributions
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: python-distributions
           path: dist/
@@ -105,7 +105,7 @@ jobs:
       id-token: write
     steps:
       - name: Download verified distributions
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: python-distributions
           path: dist/

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -133,13 +133,13 @@ def test_publish_builds_once_verifies_and_retains_exact_distributions() -> None:
     assert "pyproject.toml" in smoke
     assert "/vm version" in smoke
     upload = build_steps["Retain built distributions"]
-    assert upload["uses"] == "actions/upload-artifact@v6"
+    assert upload["uses"] == "actions/upload-artifact@v7"
     assert upload["with"]["name"] == "python-distributions"
     assert upload["with"]["path"] == "dist/"
     assert upload["with"]["if-no-files-found"] == "error"
     assert jobs["publish"]["needs"] == "build"
     download = publish_steps["Download verified distributions"]
-    assert download["uses"] == "actions/download-artifact@v7"
+    assert download["uses"] == "actions/download-artifact@v8"
     assert download["with"]["name"] == upload["with"]["name"]
 
 


### PR DESCRIPTION
## Summary

- update `actions/upload-artifact` to v7
- update `actions/download-artifact` to v8
- keep release workflow contract tests aligned

These supersede Dependabot PRs #26 and #27, which changed one action at a time and intentionally failed the paired workflow contract test.