### PR TITLE
Add offline wiki quality evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,18 @@ jobs:
           python -m venv /tmp/vaultmind-wheel-test
           /tmp/vaultmind-wheel-test/bin/pip install dist/*.whl
           test "$(/tmp/vaultmind-wheel-test/bin/vm version)" = "VaultMind v${EXPECTED_VERSION}"
+
+      - name: Offline 20-source evaluation
+        env:
+          ANTHROPIC_API_KEY: ""
+          OPENAI_API_KEY: ""
+        run: uv run python scripts/evaluate_fixture.py --output evaluation-report.json --check
+
+      - name: Upload evaluation report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: evaluation-report
+          path: evaluation-report.json
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -350,6 +350,18 @@ not include prompts, API keys, or response bodies.
 3. Surface deterministic `vm lint` findings in compile and Ask workflows, and evaluate opt-in autofix.
 4. Improve citation verification while preserving readable, contract-compliant concept and query pages.
 
+## Measured Quality Gate
+
+The core quality claim is checked by a deterministic, offline 20-source evaluation. It exercises production Compile, manifest reconciliation, index rebuilding, Ask filing and reuse, and Lint with prompt-matched replay responses. CI fails on regressions in current compiled coverage, concept/graph coherence, reciprocal provenance, lint health, query support/reuse, or unchanged incremental stability.
+
+Run it locally with:
+
+```bash
+uv run python scripts/evaluate_fixture.py --output evaluation-report.json --check
+```
+
+See [Offline Evaluation](docs/EVALUATION.md) for metric definitions, fixture maintenance, threshold governance, and live/offline boundaries.
+
 ## Success Criteria
 
 VaultMind is working when:

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -1,0 +1,79 @@
+# Offline Evaluation
+
+VaultMind has a deterministic developer quality gate for the claim that a representative corpus becomes a grounded, connected, reusable wiki. It is not a public `vm` command and does not alter production provider or workflow semantics.
+
+## Run it
+
+```bash
+uv run python scripts/evaluate_fixture.py --output evaluation-report.json --check
+```
+
+`--output` writes stable JSON. `--check` exits 1 after writing the report when any threshold fails. If evaluation cannot complete, the script exits 2 and still writes a safe artifact containing only the exception type and a stable fingerprint—never raw exception text, prompts, paths, or secrets. Without `--check`, completed threshold failures remain visible in `failures` but the process exits normally. CI runs with no provider credentials and requires `evaluation-report.json` to exist before retaining it as an artifact.
+
+The harness deliberately blocks socket connections. It uses only `ReplayProvider`, creates a temporary vault, copies the corpus into that vault, and deletes it after measurement. Never point the harness at a personal vault. Live-provider experimentation belongs outside this benchmark: live output is nondeterministic, costs money, can expose private data, and is not comparable to the committed baseline.
+
+## Production paths exercised
+
+The runner invokes the production Compile command orchestration for both corpus phases and a third unchanged invocation, including its changed-source selection, manifest reconciliation/persistence, concept create/update, and index-trigger decisions. Between phases one and two, it injects three deterministic manifest-only inconsistencies in the temporary vault: a ghost article entry, an incorrect canonical article hash, and an incorrect source back-reference. Production Compile phase two must reconcile all three against concept files on disk. The probe uses fixed labels and existing manifest values; it adds no timestamp or path to the fixture or report, and repaired probe state is absent before final quality measurement.
+
+The runner also uses the production Raw scanner, atomic markdown writer, Ask search/filing loop, command scanners, and canonical lint logic. Replay replaces provider completion; configuration and human command output are injected at the command boundary. During the unchanged invocation, the harness instruments writes, temporary creates, and atomic replacements to VaultMind-owned files under `🗺️ Wiki/` plus `vault.manifest.json`. It also compares before/after content hashes as a secondary assertion; Raw, `VAULTMIND.md`, and application logs outside the vault are excluded.
+
+The report intentionally contains no timestamps, temporary paths, response text, prompts, environment values, or file hashes. Repeated runs produce byte-identical JSON even though production files inside each disposable vault use normal runtime timestamps.
+
+## Metrics
+
+All ratios are in `[0, 1]`; an empty expectation set has ratio `1.0`.
+
+- **Corpus/scanned source count**: declared fixture documents and Raw records observed by the production scanner.
+- **Current compiled coverage**: current-hash Raw records with at least one durable reciprocal back-reference: manifest source → concept, concept frontmatter → source, and manifest article → source must all exist.
+- **Concept count / expected concept recall**: persisted concept pages and the fraction of declared concept slugs present.
+- **Source-to-concept attribution**: expected fixture source IDs are resolved to their canonical source URLs and compared with persisted concept citations and manifest back-references. The report includes expected-pair recall, unexpected-pair count, and assignment precision.
+- **Suspicious duplicate pairs**: canonical `duplicate_concept` lint pairs.
+- **Citation/provenance inconsistencies**: differences between concept and manifest article source lists, missing source records, and missing links in either direction between manifest sources and articles.
+- **Expected graph-edge recall**: found directed `(source concept, target concept)` wikilinks divided by explicit expected edges. Targets are normalized with production wikilink rules. Backtick and tilde fenced examples do not count.
+- **Duplicate connection count**: repeated normalized targets beyond the first occurrence in each real `Connections` section.
+- **Index quality**: whether the production index file exists, expected concept-link count and recall, and unique unexpected/stale link count. Links use canonical wikilink normalization; aliases, paths, headings, and fenced examples cannot evade the measurement.
+- **Broken wikilinks / stale manifest findings / lint findings**: counts from canonical deterministic lint output.
+- **Query support**: parsed only from the persisted query-page contract. `Supporting Wiki Pages` is classified as concept-page or previously filed-query support by path; `Supporting Raw Sources` records Raw fallback. Wiki-supported rate accepts either concept or filed-query evidence. The report separately counts concept support, filed-query support, Raw support, Raw fallback, and filed-query reuse.
+- **Query expectation pass rate**: fraction of fixture queries containing every declared support class and the declared filed-query reuse behavior.
+- **Incremental writes/changed files/provider calls**: observed owned-state write attempts, changed owned-state hashes, and replay calls during the unchanged production Compile invocation. The zero-write gate detects same-byte rewrites and temporary writes that a final content snapshot cannot.
+- **Reconciliation probe**: stable per-inconsistency results plus repaired count and success rate for the ghost article, incorrect article hash, and incorrect source back-reference injected before production Compile phase two. The committed gate requires full success.
+
+`provider_call_count` is diagnostic, not a cost estimate.
+
+## Fixture design
+
+`tests/fixtures/evaluation/corpus.json` contains exactly 20 synthetic Raw sources. Five explicitly attributed sources substantially support each of four overlapping concepts: Retrieval Grounding, Citation Provenance, Knowledge Graphs, and Incremental Compilation. Sixteen phase-one sources create the concepts; four phase-two sources exercise production article updates and compounding provenance. Bodies cross-reference neighboring ideas so the desired result is four compounding pages rather than twenty isolated summaries. Eight directed graph edges are explicit. Three queries cover concept support, reuse of a filed answer, and one intentional Raw fallback.
+
+The corpus uses reserved `evaluation.example` URLs and contains no private text, generated timestamp, absolute path, credential, or API key.
+
+## Replay maintenance
+
+`tests/fixtures/evaluation/replay.json` holds conjunctive prompt-match rules for triage, deduplication, concurrent article generation, index rebuild, and Ask. Matching is by rule, not global response order. Every rule has a finite response queue. An unmatched, ambiguous, or exhausted request raises a typed error containing only bounded SHA-256 fingerprints and character counts—not prompt content.
+
+When a production prompt changes:
+
+1. Run the evaluation and identify the safe rule ID/fingerprint that failed.
+2. Update the narrowest stable match fragments; do not copy secrets or machine paths.
+3. Review response grounding against the corpus and preserve explicit citations/edges.
+4. Run the full quality command and confirm two report renders are byte-identical.
+5. Review fixture diffs as benchmark changes, not snapshots to update blindly.
+
+Avoid broad fragments that can match multiple call shapes. Article rules must remain concept-specific so concurrent generation cannot consume another concept's response.
+
+## Threshold governance
+
+`tests/fixtures/evaluation/thresholds.json` is reviewed policy. Threshold evaluation is inclusive and reports every failure sorted by metric. Baseline thresholds should change only with an explained product-quality decision or an intentional fixture redesign. Do not automatically ratchet or rewrite them from current output. A regression should normally fix production behavior or replay grounding, not weaken the gate.
+
+Interpret failures by layer:
+
+- coverage or provenance: inspect article citations and manifest reciprocity;
+- graph recall/duplicates: inspect real `Connections` links and deduplication;
+- index: inspect index existence and normalized expected/unexpected links;
+- reconciliation probe: inspect phase-two manifest repair behavior against canonical disk state;
+- lint: inspect broken targets or stale state;
+- query support/reuse: inspect persisted Supporting sections and wiki-first retrieval;
+- incremental writes/calls: inspect source hashes, reconciliation, or unconditional orchestration;
+- replay mismatch: review the production prompt shape and the narrow fixture rule.
+
+The benchmark does not judge prose with another LLM, compare vendors, call live providers, measure load, account for tokens, or replace human review.

--- a/scripts/evaluate_fixture.py
+++ b/scripts/evaluate_fixture.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Developer/CI entry point for the deterministic offline evaluation fixture."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from vaultmind.evaluation import render_report_json, run_evaluation
+from vaultmind.evaluation.models import EvaluationErrorReport
+from vaultmind.evaluation.runner import DEFAULT_FIXTURE_DIR
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, help="write the deterministic JSON report here")
+    parser.add_argument(
+        "--fixture-dir",
+        type=Path,
+        default=DEFAULT_FIXTURE_DIR,
+        help="evaluation fixture directory (defaults to the committed baseline)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero when one or more committed thresholds fail",
+    )
+    args = parser.parse_args()
+
+    # Production paths emit human logs to stdout; keep JSON stdout machine-readable.
+    try:
+        with redirect_stdout(sys.stderr):
+            report = run_evaluation(args.fixture_dir)
+        rendered = render_report_json(report)
+        exit_code = 1 if args.check and not report.passed else 0
+    except Exception as exc:
+        # Never serialize arbitrary exception text: provider/production failures
+        # may contain temporary paths or sensitive input. A stable fingerprint is
+        # enough to correlate the artifact with protected CI diagnostics.
+        error_type = type(exc).__name__[:120]
+        error_report = EvaluationErrorReport(
+            error_type=error_type,
+            error_fingerprint=hashlib.sha256(error_type.encode("utf-8")).hexdigest()[:24],
+        )
+        rendered = error_report.model_dump_json(indent=2) + "\n"
+        print(f"evaluation failed: {error_type}", file=sys.stderr)
+        exit_code = 2
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vaultmind/commands/compile.py
+++ b/src/vaultmind/commands/compile.py
@@ -40,6 +40,8 @@ from vaultmind.utils.display import print_error, print_info, print_success, prin
 from vaultmind.utils.hashing import content_hash
 from vaultmind.utils.logging import setup_logging
 
+__all__ = ["reconcile_manifest"]
+
 log = structlog.get_logger()
 
 

--- a/src/vaultmind/evaluation/__init__.py
+++ b/src/vaultmind/evaluation/__init__.py
@@ -1,0 +1,55 @@
+"""Public developer contracts for VaultMind's offline quality evaluation."""
+
+from vaultmind.evaluation.models import (
+    CorpusSource,
+    EvaluationMetrics,
+    EvaluationReport,
+    EvaluationScenario,
+    EvaluationThreshold,
+    EvaluationThresholds,
+    ExpectedConcept,
+    ExpectedEdge,
+    QueryExpectation,
+    QuerySupport,
+    ThresholdFailure,
+)
+from vaultmind.evaluation.replay import (
+    AmbiguousReplayPromptError,
+    ExhaustedReplayResponseError,
+    ReplayFixture,
+    ReplayPromptError,
+    ReplayProvider,
+    ReplayRule,
+    UnmatchedReplayPromptError,
+)
+from vaultmind.evaluation.runner import (
+    EvaluationRunError,
+    evaluate_thresholds,
+    render_report_json,
+    run_evaluation,
+)
+
+__all__ = [
+    "AmbiguousReplayPromptError",
+    "CorpusSource",
+    "EvaluationMetrics",
+    "EvaluationReport",
+    "EvaluationRunError",
+    "EvaluationScenario",
+    "EvaluationThreshold",
+    "EvaluationThresholds",
+    "ExhaustedReplayResponseError",
+    "ExpectedConcept",
+    "ExpectedEdge",
+    "QueryExpectation",
+    "QuerySupport",
+    "ReplayFixture",
+    "ReplayPromptError",
+    "ReplayProvider",
+    "ReplayRule",
+    "ThresholdFailure",
+    "UnmatchedReplayPromptError",
+    "evaluate_thresholds",
+    "render_report_json",
+    "run_evaluation",
+]

--- a/src/vaultmind/evaluation/metrics.py
+++ b/src/vaultmind/evaluation/metrics.py
@@ -1,0 +1,330 @@
+"""Deterministic quality metrics for persisted VaultMind wiki state."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+
+from vaultmind.core.linter import ConceptPage, LintReport, extract_wikilinks
+from vaultmind.core.raw_scanner import RawSourceRecord
+from vaultmind.evaluation.models import (
+    EvaluationMetrics,
+    EvaluationScenario,
+    QuerySupport,
+)
+from vaultmind.schemas import Manifest
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    """Return a stable vacuous-success ratio for an empty expectation set."""
+    return 1.0 if denominator == 0 else numerator / denominator
+
+
+def _strip_fenced_blocks(markdown: str) -> str:
+    """Remove backtick and tilde fenced examples before graph inspection."""
+    retained: list[str] = []
+    marker: str | None = None
+    marker_length = 0
+    for line in markdown.splitlines(keepends=True):
+        if marker is not None:
+            closer = re.match(rf"^ {{0,3}}{re.escape(marker)}{{{marker_length},}}[ \t]*(?:\n)?$", line)
+            if closer:
+                marker = None
+                marker_length = 0
+            continue
+        opener = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", line.rstrip("\r\n"))
+        if opener and (opener.group(1)[0] == "~" or "`" not in opener.group(2)):
+            marker = opener.group(1)[0]
+            marker_length = len(opener.group(1))
+            continue
+        retained.append(line)
+    return "".join(retained)
+
+
+def index_quality(
+    index_markdown: str | None,
+    scenario: EvaluationScenario,
+) -> tuple[int, int, float, int]:
+    """Measure index presence, expected concept coverage, and unexpected links."""
+    expected = {concept.slug.lower() for concept in scenario.expected_concepts}
+    actual = set(
+        extract_wikilinks(_strip_fenced_blocks(index_markdown or ""))
+    )
+    return (
+        int(index_markdown is not None),
+        len(expected),
+        _ratio(len(actual & expected), len(expected)),
+        len(actual - expected),
+    )
+
+
+def graph_quality(
+    concept_pages: Sequence[ConceptPage], scenario: EvaluationScenario
+) -> tuple[float, int]:
+    """Return expected directed-edge recall and duplicate connection count."""
+    real_edges: set[tuple[str, str]] = set()
+    duplicate_connections = 0
+    for page in sorted(concept_pages, key=lambda item: item.slug):
+        cleaned = _strip_fenced_blocks(page.text)
+        links = extract_wikilinks(cleaned)
+        real_edges.update((page.slug, target) for target in links if target != page.slug)
+
+        connections = _section(cleaned, "Connections")
+        connection_links = extract_wikilinks(connections)
+        duplicate_connections += len(connection_links) - len(set(connection_links))
+
+    expected = {(edge.source.lower(), edge.target.lower()) for edge in scenario.expected_edges}
+    return _ratio(len(real_edges & expected), len(expected)), duplicate_connections
+
+
+def citation_inconsistencies(
+    raw_sources: Sequence[RawSourceRecord],
+    manifest: Manifest,
+    concept_pages: Sequence[ConceptPage],
+) -> list[str]:
+    """Check concept/manifest citations and source/article backlinks both ways."""
+    findings: set[str] = set()
+    pages = {page.slug: page for page in concept_pages}
+
+    for slug, page in sorted(pages.items()):
+        page_sources = set(page.sources)
+        entry = manifest.wiki_articles.get(slug)
+        if entry is None:
+            findings.add(f"concept_missing_manifest:{slug}")
+            manifest_sources: set[str] = set()
+        else:
+            manifest_sources = set(entry.source_urls)
+        for source in sorted(page_sources - manifest_sources):
+            findings.add(f"page_source_missing_manifest_article:{slug}:{source}")
+        for source in sorted(manifest_sources - page_sources):
+            findings.add(f"manifest_article_source_missing_page:{slug}:{source}")
+        for source in sorted(page_sources | manifest_sources):
+            source_entry = manifest.sources.get(source)
+            if source_entry is None:
+                findings.add(f"article_source_missing_manifest_source:{slug}:{source}")
+            elif slug not in source_entry.wiki_articles:
+                findings.add(f"source_backlink_missing_article:{slug}:{source}")
+
+    for source, source_manifest_entry in sorted(manifest.sources.items()):
+        for slug in sorted(set(source_manifest_entry.wiki_articles)):
+            linked_page = pages.get(slug)
+            linked_article = manifest.wiki_articles.get(slug)
+            if linked_page is None or source not in linked_page.sources:
+                findings.add(f"source_backlink_missing_page_citation:{slug}:{source}")
+            if linked_article is None or source not in linked_article.source_urls:
+                findings.add(f"source_backlink_missing_article_citation:{slug}:{source}")
+
+    raw_keys = {source.source_url or source.relative_path for source in raw_sources}
+    for source in sorted(set(manifest.sources) - raw_keys):
+        findings.add(f"manifest_source_missing_raw:{source}")
+    return sorted(findings)
+
+
+def source_concept_attribution_quality(
+    scenario: EvaluationScenario,
+    manifest: Manifest,
+    concept_pages: Sequence[ConceptPage],
+) -> tuple[int, float, int, float]:
+    """Measure persisted source-to-concept assignments against fixture semantics."""
+    source_keys_by_id = {source.id: source.source_url for source in scenario.sources}
+    expected = {
+        (source_keys_by_id[source_id], concept.slug.lower())
+        for concept in scenario.expected_concepts
+        for source_id in concept.source_ids
+    }
+
+    actual: set[tuple[str, str]] = set()
+    for page in concept_pages:
+        actual.update((source, page.slug.lower()) for source in page.sources)
+    for slug, article_entry in manifest.wiki_articles.items():
+        actual.update((source, slug.lower()) for source in article_entry.source_urls)
+    for source, source_entry in manifest.sources.items():
+        actual.update((source, slug.lower()) for slug in source_entry.wiki_articles)
+
+    matched_count = len(actual & expected)
+    unexpected_count = len(actual - expected)
+    return (
+        len(expected),
+        _ratio(matched_count, len(expected)),
+        unexpected_count,
+        _ratio(matched_count, len(actual)),
+    )
+
+
+def current_compiled_source_count(
+    raw_sources: Sequence[RawSourceRecord],
+    manifest: Manifest,
+    concept_pages: Sequence[ConceptPage],
+) -> int:
+    """Count current-hash Raw with at least one durable, reciprocal concept backlink."""
+    pages = {page.slug: page for page in concept_pages}
+    count = 0
+    for source in raw_sources:
+        key = source.source_url or source.relative_path
+        entry = manifest.sources.get(key)
+        if entry is None or entry.content_hash != source.content_hash:
+            continue
+        durable = any(
+            slug in pages
+            and key in pages[slug].sources
+            and slug in manifest.wiki_articles
+            and key in manifest.wiki_articles[slug].source_urls
+            for slug in entry.wiki_articles
+        )
+        if durable:
+            count += 1
+    return count
+
+
+def _section(markdown: str, heading: str) -> str:
+    pattern = re.compile(
+        rf"^##\s+{re.escape(heading)}\s*$(?P<body>.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(markdown)
+    return match.group("body") if match else ""
+
+
+def _query_support(markdown: str, wiki_concepts: str, wiki_queries: str) -> set[QuerySupport]:
+    support: set[QuerySupport] = set()
+    wiki_section = _section(_strip_fenced_blocks(markdown), "Supporting Wiki Pages")
+    for target in re.findall(r"\[\[([^\]|#^]+)", wiki_section):
+        normalized = target.replace("\\", "/").strip().lower()
+        if f"/{wiki_queries.lower()}/" in f"/{normalized}/":
+            support.add(QuerySupport.FILED_QUERY)
+        elif f"/{wiki_concepts.lower()}/" in f"/{normalized}/":
+            support.add(QuerySupport.CONCEPT)
+
+    raw_section = _section(_strip_fenced_blocks(markdown), "Supporting Raw Sources")
+    if any(
+        line.strip().startswith(("- ", "* ", "+ "))
+        for line in raw_section.splitlines()
+    ):
+        support.add(QuerySupport.RAW)
+    return support
+
+
+def _duplicate_pairs(lint_report: LintReport) -> list[str]:
+    pairs: set[str] = set()
+    for finding in lint_report.findings:
+        if finding.code != "duplicate_concept" or not finding.subject:
+            continue
+        match = re.search(r"Similar concept:\s+([^\s]+)", finding.message)
+        other = match.group(1) if match else "unknown"
+        pairs.add(" <-> ".join(sorted((finding.subject, other))))
+    return sorted(pairs)
+
+
+def calculate_metrics(
+    *,
+    scenario: EvaluationScenario,
+    raw_sources: Sequence[RawSourceRecord],
+    manifest: Manifest,
+    concept_pages: Sequence[ConceptPage],
+    lint_report: LintReport,
+    index_markdown: str | None,
+    query_pages: Mapping[str, str],
+    wiki_concepts_folder: str,
+    wiki_queries_folder: str,
+    incremental_changed_file_count: int,
+    incremental_owned_state_write_count: int,
+    incremental_provider_call_count: int,
+    reconciliation_probe_results: Sequence[str],
+    provider_call_count: int,
+) -> EvaluationMetrics:
+    """Calculate all report metrics from durable vault state."""
+    compiled = current_compiled_source_count(raw_sources, manifest, concept_pages)
+    page_slugs = {page.slug for page in concept_pages}
+    expected_slugs = {concept.slug for concept in scenario.expected_concepts}
+    citation_findings = citation_inconsistencies(raw_sources, manifest, concept_pages)
+    graph_recall, duplicate_connections = graph_quality(concept_pages, scenario)
+    (
+        index_present,
+        expected_index_count,
+        expected_index_recall,
+        unexpected_index_count,
+    ) = index_quality(index_markdown, scenario)
+    (
+        expected_attribution_count,
+        expected_attribution_recall,
+        unexpected_attribution_count,
+        attribution_precision,
+    ) = source_concept_attribution_quality(scenario, manifest, concept_pages)
+    duplicate_pairs = _duplicate_pairs(lint_report)
+
+    support_by_question = {
+        question: _query_support(markdown, wiki_concepts_folder, wiki_queries_folder)
+        for question, markdown in sorted(query_pages.items())
+    }
+    query_count = len(support_by_question)
+    concept_supported = sum(
+        QuerySupport.CONCEPT in support for support in support_by_question.values()
+    )
+    filed_supported = sum(
+        QuerySupport.FILED_QUERY in support for support in support_by_question.values()
+    )
+    raw_supported = sum(QuerySupport.RAW in support for support in support_by_question.values())
+    wiki_supported = sum(
+        bool(support & {QuerySupport.CONCEPT, QuerySupport.FILED_QUERY})
+        for support in support_by_question.values()
+    )
+
+    probe_results = list(reconciliation_probe_results)
+    repaired_probe_count = sum(
+        result.endswith(":repaired") for result in probe_results
+    )
+
+    expectation_passes = 0
+    for expectation in scenario.queries:
+        actual = support_by_question.get(expectation.question, set())
+        expected = set(expectation.support)
+        if expected <= actual and (
+            (QuerySupport.FILED_QUERY in actual) == expectation.reuses_filed_query
+        ):
+            expectation_passes += 1
+
+    return EvaluationMetrics(
+        corpus_source_count=len(scenario.sources),
+        scanned_source_count=len(raw_sources),
+        current_compiled_source_count=compiled,
+        current_compiled_coverage=_ratio(compiled, len(raw_sources)),
+        concept_count=len(concept_pages),
+        expected_concept_recall=_ratio(len(page_slugs & expected_slugs), len(expected_slugs)),
+        expected_source_to_concept_attribution_count=expected_attribution_count,
+        expected_source_to_concept_attribution_recall=expected_attribution_recall,
+        unexpected_source_to_concept_attribution_count=unexpected_attribution_count,
+        source_to_concept_attribution_precision=attribution_precision,
+        suspicious_duplicate_pairs=duplicate_pairs,
+        suspicious_duplicate_pair_count=len(duplicate_pairs),
+        citation_provenance_inconsistencies=citation_findings,
+        citation_provenance_inconsistency_count=len(citation_findings),
+        expected_graph_edge_count=len(scenario.expected_edges),
+        expected_graph_edge_recall=graph_recall,
+        duplicate_connection_count=duplicate_connections,
+        index_present=index_present,
+        expected_concept_index_link_count=expected_index_count,
+        expected_concept_index_link_recall=expected_index_recall,
+        unexpected_index_link_count=unexpected_index_count,
+        broken_wikilinks=sum(f.code == "broken_wikilink" for f in lint_report.findings),
+        stale_manifest_findings=sum(
+            f.code in {"stale_manifest_concept", "stale_manifest_source"}
+            for f in lint_report.findings
+        ),
+        lint_finding_count=lint_report.total,
+        query_count=query_count,
+        concept_supported_query_count=concept_supported,
+        filed_query_supported_query_count=filed_supported,
+        raw_supported_query_count=raw_supported,
+        wiki_supported_query_rate=_ratio(wiki_supported, query_count),
+        raw_fallback_count=raw_supported,
+        filed_query_reuse_count=filed_supported,
+        query_expectation_pass_rate=_ratio(expectation_passes, len(scenario.queries)),
+        incremental_changed_file_count=incremental_changed_file_count,
+        incremental_owned_state_write_count=incremental_owned_state_write_count,
+        incremental_provider_call_count=incremental_provider_call_count,
+        reconciliation_probe_results=probe_results,
+        reconciliation_probe_inconsistency_count=len(probe_results),
+        reconciliation_probe_repaired_count=repaired_probe_count,
+        reconciliation_probe_success_rate=_ratio(repaired_probe_count, len(probe_results)),
+        provider_call_count=provider_call_count,
+    )

--- a/src/vaultmind/evaluation/models.py
+++ b/src/vaultmind/evaluation/models.py
@@ -1,0 +1,182 @@
+"""Typed contracts for the deterministic offline evaluation harness."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class QuerySupport(StrEnum):
+    """Persisted evidence classes available to a filed query page."""
+
+    CONCEPT = "concept"
+    FILED_QUERY = "filed_query"
+    RAW = "raw"
+
+
+class CorpusSource(BaseModel):
+    """One Raw document materialized in the isolated evaluation vault."""
+
+    id: str
+    title: str
+    source_url: str
+    tags: list[str] = Field(default_factory=list)
+    body: str
+    phase: int = Field(default=1, ge=1)
+
+
+class ExpectedConcept(BaseModel):
+    """A concept expected from the representative corpus."""
+
+    slug: str
+    title: str
+    source_ids: list[str] = Field(default_factory=list)
+
+
+class ExpectedEdge(BaseModel):
+    """A directed concept wikilink expected in the compiled graph."""
+
+    source: str
+    target: str
+
+
+class QueryExpectation(BaseModel):
+    """Expected persisted support for one production Ask invocation."""
+
+    question: str
+    support: list[QuerySupport]
+    reuses_filed_query: bool = False
+
+
+class EvaluationScenario(BaseModel):
+    """Complete corpus and quality expectations for one replay scenario."""
+
+    name: str
+    sources: list[CorpusSource]
+    expected_concepts: list[ExpectedConcept]
+    expected_edges: list[ExpectedEdge]
+    queries: list[QueryExpectation]
+
+    @model_validator(mode="after")
+    def validate_unique_identity(self) -> EvaluationScenario:
+        """Reject ambiguous fixture identities before any vault is mutated."""
+        for label, values in (
+            ("source id", [source.id for source in self.sources]),
+            ("source URL", [source.source_url for source in self.sources]),
+            ("concept slug", [concept.slug for concept in self.expected_concepts]),
+            ("query", [query.question for query in self.queries]),
+        ):
+            if len(values) != len(set(values)):
+                raise ValueError(f"duplicate {label} in evaluation scenario")
+        source_ids = {source.id for source in self.sources}
+        unknown_ids = sorted(
+            source_id
+            for concept in self.expected_concepts
+            for source_id in concept.source_ids
+            if source_id not in source_ids
+        )
+        if unknown_ids:
+            raise ValueError(f"unknown expected concept source ids: {', '.join(unknown_ids)}")
+        return self
+
+
+class EvaluationThreshold(BaseModel):
+    """An inclusive lower and/or upper quality bound for one numeric metric."""
+
+    metric: str
+    minimum: float | None = None
+    maximum: float | None = None
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> EvaluationThreshold:
+        if self.minimum is None and self.maximum is None:
+            raise ValueError("threshold must define minimum or maximum")
+        if (
+            self.minimum is not None
+            and self.maximum is not None
+            and self.minimum > self.maximum
+        ):
+            raise ValueError("threshold minimum cannot exceed maximum")
+        return self
+
+
+class EvaluationThresholds(BaseModel):
+    """Named threshold set checked by developer and CI evaluation runs."""
+
+    name: str
+    thresholds: list[EvaluationThreshold]
+
+
+class EvaluationMetrics(BaseModel):
+    """Stable machine-readable measurements from Compile, Ask, and Lint."""
+
+    corpus_source_count: int
+    scanned_source_count: int
+    current_compiled_source_count: int
+    current_compiled_coverage: float
+    concept_count: int
+    expected_concept_recall: float
+    expected_source_to_concept_attribution_count: int
+    expected_source_to_concept_attribution_recall: float
+    unexpected_source_to_concept_attribution_count: int
+    source_to_concept_attribution_precision: float
+    suspicious_duplicate_pairs: list[str]
+    suspicious_duplicate_pair_count: int
+    citation_provenance_inconsistencies: list[str]
+    citation_provenance_inconsistency_count: int
+    expected_graph_edge_count: int
+    expected_graph_edge_recall: float
+    duplicate_connection_count: int
+    index_present: int
+    expected_concept_index_link_count: int
+    expected_concept_index_link_recall: float
+    unexpected_index_link_count: int
+    broken_wikilinks: int
+    stale_manifest_findings: int
+    lint_finding_count: int
+    query_count: int
+    concept_supported_query_count: int
+    filed_query_supported_query_count: int
+    raw_supported_query_count: int
+    wiki_supported_query_rate: float
+    raw_fallback_count: int
+    filed_query_reuse_count: int
+    query_expectation_pass_rate: float
+    incremental_changed_file_count: int
+    incremental_owned_state_write_count: int
+    incremental_provider_call_count: int
+    reconciliation_probe_results: list[str]
+    reconciliation_probe_inconsistency_count: int
+    reconciliation_probe_repaired_count: int
+    reconciliation_probe_success_rate: float
+    provider_call_count: int
+
+
+class ThresholdFailure(BaseModel):
+    """One failed quality bound; reports retain all failures in stable order."""
+
+    metric: str
+    actual: float
+    minimum: float | None = None
+    maximum: float | None = None
+
+
+class EvaluationReport(BaseModel):
+    """Deterministic final evaluation artifact."""
+
+    schema_version: int = 1
+    scenario: str
+    threshold_set: str
+    metrics: EvaluationMetrics
+    failures: list[ThresholdFailure]
+    passed: bool
+
+
+class EvaluationErrorReport(BaseModel):
+    """Safe artifact emitted when evaluation cannot produce quality metrics."""
+
+    schema_version: int = 1
+    passed: bool = False
+    error_type: str
+    error_fingerprint: str

--- a/src/vaultmind/evaluation/replay.py
+++ b/src/vaultmind/evaluation/replay.py
@@ -1,0 +1,132 @@
+"""Concurrency-safe prompt-matched replay provider for offline evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from vaultmind.ai.providers.base import FailureKind
+
+PROMPT_FINGERPRINT_HEX_CHARS = 16
+
+
+class ReplayPromptError(Exception):
+    """Base class for safe deterministic replay failures."""
+
+
+class UnmatchedReplayPromptError(ReplayPromptError):
+    """No replay rule matched a provider request."""
+
+
+class ExhaustedReplayResponseError(ReplayPromptError):
+    """A matching replay rule has no response left."""
+
+
+class AmbiguousReplayPromptError(ReplayPromptError):
+    """More than one replay rule matched a provider request."""
+
+
+class ReplayMatch(BaseModel):
+    """Conjunctive, order-independent match criteria for a provider request."""
+
+    prompt_contains: list[str] = Field(default_factory=list)
+    system_contains: list[str] = Field(default_factory=list)
+
+
+class ReplayRule(BaseModel):
+    """A named match rule and its finite ordered response queue."""
+
+    id: str
+    match: ReplayMatch
+    responses: list[str]
+
+
+class ReplayFixture(BaseModel):
+    """Serialized replay-provider configuration."""
+
+    rules: list[ReplayRule]
+
+
+def prompt_fingerprint(prompt: str, system: str = "") -> str:
+    """Return a bounded fingerprint without retaining prompt content."""
+    prompt_digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    system_digest = hashlib.sha256(system.encode("utf-8")).hexdigest()
+    return (
+        f"prompt_sha256={prompt_digest[:PROMPT_FINGERPRINT_HEX_CHARS]} "
+        f"system_sha256={system_digest[:PROMPT_FINGERPRINT_HEX_CHARS]} "
+        f"prompt_chars={len(prompt)} system_chars={len(system)}"
+    )
+
+
+class ReplayProvider:
+    """Provider whose responses are selected by prompt, never global call order."""
+
+    name = "offline-replay"
+    model = "fixture-v1"
+
+    def __init__(self, fixture: ReplayFixture) -> None:
+        ids = [rule.id for rule in fixture.rules]
+        if len(ids) != len(set(ids)):
+            raise ValueError("replay rule ids must be unique")
+        self._rules = tuple(fixture.rules)
+        self._consumed = {rule.id: 0 for rule in fixture.rules}
+        self._call_count = 0
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    def from_path(cls, path: Path) -> ReplayProvider:
+        """Load replay rules from JSON without consulting environment state."""
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return cls(ReplayFixture.model_validate(data))
+
+    @property
+    def call_count(self) -> int:
+        """Return every attempted completion request, including replay failures."""
+        return self._call_count
+
+    @property
+    def consumed_by_rule(self) -> dict[str, int]:
+        """Return a stable diagnostic snapshot without prompt or response content."""
+        return {rule.id: self._consumed[rule.id] for rule in self._rules}
+
+    async def complete(self, prompt: str, system: str = "") -> str:
+        """Atomically match and consume one rule-specific response."""
+        async with self._lock:
+            self._call_count += 1
+            matches = [rule for rule in self._rules if self._matches(rule, prompt, system)]
+            fingerprint = prompt_fingerprint(prompt, system)
+            if not matches:
+                raise UnmatchedReplayPromptError(f"unmatched replay request ({fingerprint})")
+            if len(matches) > 1:
+                ids = ",".join(sorted(rule.id for rule in matches))[:160]
+                raise AmbiguousReplayPromptError(
+                    f"ambiguous replay request rules={ids} ({fingerprint})"
+                )
+
+            rule = matches[0]
+            consumed = self._consumed[rule.id]
+            if consumed >= len(rule.responses):
+                raise ExhaustedReplayResponseError(
+                    f"exhausted replay rule={rule.id[:80]} ({fingerprint})"
+                )
+            response = rule.responses[consumed]
+            self._consumed[rule.id] = consumed + 1
+            return response
+
+    @staticmethod
+    def _matches(rule: ReplayRule, prompt: str, system: str) -> bool:
+        return all(part in prompt for part in rule.match.prompt_contains) and all(
+            part in system for part in rule.match.system_contains
+        )
+
+    def classify_failure(self, exc: Exception) -> FailureKind:
+        """Replay fixture errors are deterministic invalid-request failures."""
+        return FailureKind.REQUEST
+
+    def is_retryable_failure(self, exc: Exception) -> bool:
+        """Replay mismatches cannot become valid through retrying."""
+        return False

--- a/src/vaultmind/evaluation/runner.py
+++ b/src/vaultmind/evaluation/runner.py
@@ -1,0 +1,527 @@
+"""Isolated end-to-end runner for the checked-in offline evaluation fixture."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import hashlib
+import json
+import os
+import shutil
+import socket
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import typer
+import yaml
+
+import vaultmind.commands.compile as compile_command
+from vaultmind.ai.asker import ask_question
+from vaultmind.commands.lint import _scan_all_targets, _scan_concept_pages, _scan_wiki_pages
+from vaultmind.config import AppConfig, EnvSettings, FolderConfig
+from vaultmind.core.linter import LintReport, lint_vault
+from vaultmind.core.manifest import read_manifest, write_manifest
+from vaultmind.core.raw_scanner import scan_raw_sources
+from vaultmind.evaluation.metrics import calculate_metrics
+from vaultmind.evaluation.models import (
+    EvaluationReport,
+    EvaluationScenario,
+    EvaluationThresholds,
+    ThresholdFailure,
+)
+from vaultmind.evaluation.replay import ReplayProvider
+from vaultmind.schemas import Manifest
+from vaultmind.utils.hashing import content_hash
+
+DEFAULT_FIXTURE_DIR = Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "evaluation"
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "vault" / "VAULTMIND.md"
+
+
+class EvaluationRunError(Exception):
+    """The fixture could not complete through the real production paths."""
+
+
+class OfflineNetworkError(EvaluationRunError):
+    """Code attempted network I/O during an offline evaluation."""
+
+
+@dataclass(frozen=True, slots=True)
+class _ReconciliationProbe:
+    """Deterministic manifest-only drift injected between production phases."""
+
+    concept_slug: str
+    source_key: str
+    ghost_slug: str = "reconciliation-probe-ghost"
+
+
+def load_scenario(path: Path) -> EvaluationScenario:
+    """Load and validate an evaluation corpus fixture."""
+    return EvaluationScenario.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+
+def load_thresholds(path: Path) -> EvaluationThresholds:
+    """Load and validate quality bounds."""
+    return EvaluationThresholds.model_validate(json.loads(path.read_text(encoding="utf-8")))
+
+
+def evaluate_thresholds(
+    metrics: object, thresholds: EvaluationThresholds
+) -> list[ThresholdFailure]:
+    """Evaluate every threshold and return all failures sorted by metric name."""
+    failures: list[ThresholdFailure] = []
+    for threshold in sorted(thresholds.thresholds, key=lambda item: item.metric):
+        raw_actual = getattr(metrics, threshold.metric, None)
+        if isinstance(raw_actual, bool) or not isinstance(raw_actual, (int, float)):
+            raise ValueError(f"threshold metric is not numeric: {threshold.metric}")
+        actual = float(raw_actual)
+        below = threshold.minimum is not None and actual < threshold.minimum
+        above = threshold.maximum is not None and actual > threshold.maximum
+        if below or above:
+            failures.append(
+                ThresholdFailure(
+                    metric=threshold.metric,
+                    actual=actual,
+                    minimum=threshold.minimum,
+                    maximum=threshold.maximum,
+                )
+            )
+    return failures
+
+
+def render_report_json(report: EvaluationReport) -> str:
+    """Render canonical report JSON with fixed formatting and a final newline."""
+    return report.model_dump_json(indent=2) + "\n"
+
+
+@contextmanager
+def _network_blocked() -> Iterator[None]:
+    def reject(*args: object, **kwargs: object) -> None:
+        raise OfflineNetworkError("network access is disabled during offline evaluation")
+
+    with (
+        patch.object(socket.socket, "connect", reject),
+        patch.object(socket.socket, "connect_ex", reject),
+        patch("socket.create_connection", reject),
+        patch("socket.getaddrinfo", reject),
+    ):
+        yield
+
+
+def _materialize_sources(
+    vault_path: Path, scenario: EvaluationScenario, *, phase: int
+) -> None:
+    """Add one declared corpus phase without rewriting earlier Raw files."""
+    raw_dir = vault_path / FolderConfig().raw
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    for index, source in enumerate(scenario.sources, start=1):
+        if source.phase != phase:
+            continue
+        frontmatter = yaml.safe_dump(
+            {"source": source.source_url, "tags": source.tags},
+            allow_unicode=True,
+            sort_keys=False,
+        ).rstrip()
+        body = source.body.rstrip()
+        content = f"---\n{frontmatter}\n---\n\n# {source.title}\n\n{body}\n"
+        (raw_dir / f"{index:02d}-{source.id}.md").write_text(content, encoding="utf-8")
+
+
+def _materialize_vault(
+    vault_path: Path, scenario: EvaluationScenario, schema_path: Path
+) -> AppConfig:
+    """Create the first corpus phase in a fresh temporary vault."""
+    folders = FolderConfig()
+    _materialize_sources(vault_path, scenario, phase=1)
+    shutil.copyfile(schema_path, vault_path / "VAULTMIND.md")
+    return AppConfig(
+        vault_path=vault_path,
+        folders=folders,
+        env=EnvSettings(
+            anthropic_api_key="",
+            openai_api_key="",
+            ollama_base_url="",
+        ),
+    )
+
+
+def _discard_command_output(*args: object, **kwargs: object) -> None:
+    """Keep production command display side effects out of deterministic evaluation output."""
+
+
+def _run_production_compile(config: AppConfig, provider: ReplayProvider) -> None:
+    """Invoke the production compile command with only external dependencies replaced."""
+    try:
+        with (
+            patch.object(compile_command, "load_config", return_value=config),
+            patch.object(compile_command, "get_provider", return_value=provider),
+            patch.object(compile_command, "setup_logging", _discard_command_output),
+            patch.object(compile_command, "print_error", _discard_command_output),
+            patch.object(compile_command, "print_info", _discard_command_output),
+            patch.object(compile_command, "print_success", _discard_command_output),
+            patch.object(compile_command, "print_warning", _discard_command_output),
+        ):
+            compile_command._compile(
+                full=False,
+                dry_run=False,
+                verbose=False,
+                max_touches=5,
+            )
+    except typer.Exit as exc:
+        raise EvaluationRunError(
+            f"production compile exited with status {exc.exit_code}"
+        ) from exc
+
+
+async def _run_queries(
+    config: AppConfig,
+    scenario: EvaluationScenario,
+    provider: ReplayProvider,
+) -> dict[str, str]:
+    pages: dict[str, str] = {}
+    for expectation in scenario.queries:
+        result = await ask_question(
+            expectation.question,
+            provider,
+            config.vault_path,
+            config.folders.wiki,
+            config.folders.wiki_concepts,
+            config.folders.wiki_queries,
+            config.folders.raw,
+            depth="shallow",
+            file_answer=True,
+        )
+        pages[expectation.question] = result.path.read_text(encoding="utf-8")
+    return pages
+
+
+def _inject_reconciliation_probe(
+    config: AppConfig,
+    scenario: EvaluationScenario,
+) -> _ReconciliationProbe:
+    """Persist safe manifest drift whose canonical values already exist on disk."""
+    phase_one_ids = {source.id for source in scenario.sources if source.phase == 1}
+    candidates = sorted(
+        [
+            concept
+            for concept in scenario.expected_concepts
+            if phase_one_ids.intersection(concept.source_ids)
+        ],
+        key=lambda concept: concept.slug,
+    )
+    if not candidates:
+        raise EvaluationRunError("reconciliation probe requires a phase-one concept")
+
+    concept = candidates[0]
+    sources_by_id = {source.id: source for source in scenario.sources}
+    source_id = min(source_id for source_id in concept.source_ids if source_id in phase_one_ids)
+    source_key = sources_by_id[source_id].source_url
+    probe = _ReconciliationProbe(concept_slug=concept.slug, source_key=source_key)
+
+    manifest = read_manifest(config.vault_path)
+    article_entry = manifest.wiki_articles.get(probe.concept_slug)
+    source_entry = manifest.sources.get(probe.source_key)
+    if article_entry is None or source_entry is None:
+        raise EvaluationRunError("phase one did not create reconciliation probe targets")
+
+    manifest.wiki_articles[probe.concept_slug] = article_entry.model_copy(
+        update={"content_hash": "reconciliation-probe-incorrect-hash"}
+    )
+    manifest.wiki_articles[probe.ghost_slug] = article_entry.model_copy(
+        update={"content_hash": "reconciliation-probe-ghost-hash"}
+    )
+    manifest.sources[probe.source_key] = source_entry.model_copy(
+        update={"wiki_articles": [probe.ghost_slug]}
+    )
+    write_manifest(config.vault_path, manifest)
+    return probe
+
+
+def _verify_reconciliation_probe(
+    config: AppConfig,
+    probe: _ReconciliationProbe,
+    manifest: Manifest | None = None,
+) -> list[str]:
+    """Report each probe repair against canonical concept files on disk."""
+    manifest = manifest if manifest is not None else read_manifest(config.vault_path)
+    article_entry = manifest.wiki_articles.get(probe.concept_slug)
+    article_path = _concept_path(config, probe.concept_slug)
+    hash_repaired = (
+        article_entry is not None
+        and article_path.is_file()
+        and article_entry.content_hash
+        == content_hash(article_path.read_text(encoding="utf-8"))
+    )
+
+    canonical_backlinks = sorted(
+        page.slug
+        for page in _scan_concept_pages(config)
+        if probe.source_key in page.sources
+    )
+    source_entry = manifest.sources.get(probe.source_key)
+    backlink_repaired = (
+        source_entry is not None
+        and source_entry.wiki_articles == canonical_backlinks
+    )
+    results = [
+        ("concept_hash", hash_repaired),
+        ("ghost_wiki_entry", probe.ghost_slug not in manifest.wiki_articles),
+        ("source_back_reference", backlink_repaired),
+    ]
+    return [f"{name}:{'repaired' if repaired else 'unrepaired'}" for name, repaired in results]
+
+
+@contextmanager
+def _observe_reconciliation_probe(
+    config: AppConfig,
+    probe: _ReconciliationProbe,
+) -> Iterator[list[list[str]]]:
+    """Capture probe state immediately after each production reconciliation call."""
+    production_reconcile = compile_command.reconcile_manifest
+    observations: list[list[str]] = []
+
+    def observed_reconcile(
+        manifest: Any,
+        *,
+        concepts_dir: Path,
+        current_raw_keys: set[str],
+    ) -> Any:
+        result = production_reconcile(
+            manifest,
+            concepts_dir=concepts_dir,
+            current_raw_keys=current_raw_keys,
+        )
+        observations.append(_verify_reconciliation_probe(config, probe, result.manifest))
+        return result
+
+    with patch.object(compile_command, "reconcile_manifest", observed_reconcile):
+        yield observations
+
+
+def _concept_path(config: AppConfig, slug: str) -> Path:
+    return (
+        config.vault_path
+        / config.folders.wiki
+        / config.folders.wiki_concepts
+        / f"{slug}.md"
+    )
+
+
+def _run_lint(config: AppConfig) -> LintReport:
+    """Exercise canonical deterministic lint logic over production scanners."""
+    raw_sources = scan_raw_sources(config)
+    manifest = read_manifest(config.vault_path)
+    concept_pages = _scan_concept_pages(config)
+    wiki_pages = _scan_wiki_pages(config)
+    index_path = config.vault_path / config.folders.wiki / f"{config.folders.wiki_index}.md"
+    index_text = index_path.read_text(encoding="utf-8") if index_path.exists() else ""
+    concept_slugs = {page.slug for page in concept_pages}
+    return lint_vault(
+        raw_sources=raw_sources,
+        manifest=manifest,
+        concept_pages=concept_pages,
+        wiki_pages=wiki_pages,
+        index_text=index_text,
+        valid_targets=_scan_all_targets(config),
+        concept_slugs=concept_slugs,
+    )
+
+
+def _owned_state_hashes(config: AppConfig) -> dict[str, str]:
+    """Hash every vault-owned state file, excluding human Raw/schema and external logs."""
+    owned: list[Path] = []
+    manifest_path = config.vault_path / "vault.manifest.json"
+    if manifest_path.is_file():
+        owned.append(manifest_path)
+    wiki_path = config.vault_path / config.folders.wiki
+    if wiki_path.exists():
+        owned.extend(path for path in wiki_path.rglob("*") if path.is_file())
+    return {
+        path.relative_to(config.vault_path).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(owned, key=lambda item: item.relative_to(config.vault_path).as_posix())
+    }
+
+
+def _changed_hash_count(before: dict[str, str], after: dict[str, str]) -> int:
+    return sum(before.get(path) != after.get(path) for path in sorted(set(before) | set(after)))
+
+
+def _is_owned_state_path(config: AppConfig, value: object) -> bool:
+    if isinstance(value, int):
+        return False
+    try:
+        path = Path(value)  # type: ignore[arg-type]
+        relative = path.resolve().relative_to(config.vault_path.resolve())
+    except (OSError, TypeError, ValueError):
+        return False
+    if not relative.parts:
+        return False
+    return relative.parts[0] == config.folders.wiki or relative.name.startswith(
+        "vault.manifest.json"
+    )
+
+
+@contextmanager
+def _observe_owned_state_writes(config: AppConfig) -> Iterator[list[str]]:
+    """Record attempted writes, temporary creates, and replacements in owned state."""
+    writes: list[str] = []
+    nested_path_write = 0
+    original_path_open = Path.open
+    original_write_text = Path.write_text
+    original_write_bytes = Path.write_bytes
+    original_builtin_open = builtins.open
+    original_os_open = os.open
+    original_os_replace = os.replace
+
+    def record(operation: str, value: object) -> None:
+        if _is_owned_state_path(config, value):
+            writes.append(f"{operation}:{Path(value).name}")  # type: ignore[arg-type]
+
+    def observed_path_open(path: Path, *args: Any, **kwargs: Any) -> Any:
+        mode = args[0] if args else kwargs.get("mode", "r")
+        if nested_path_write == 0 and any(flag in str(mode) for flag in "wax+"):
+            record("open", path)
+        return original_path_open(path, *args, **kwargs)
+
+    def observed_write_text(path: Path, *args: Any, **kwargs: Any) -> int:
+        nonlocal nested_path_write
+        record("write_text", path)
+        nested_path_write += 1
+        try:
+            return original_write_text(path, *args, **kwargs)
+        finally:
+            nested_path_write -= 1
+
+    def observed_write_bytes(path: Path, *args: Any, **kwargs: Any) -> int:
+        nonlocal nested_path_write
+        record("write_bytes", path)
+        nested_path_write += 1
+        try:
+            return original_write_bytes(path, *args, **kwargs)
+        finally:
+            nested_path_write -= 1
+
+    def observed_builtin_open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+        if any(flag in mode for flag in "wax+"):
+            record("open", file)
+        return original_builtin_open(file, mode, *args, **kwargs)
+
+    def observed_os_open(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        if flags & (os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_APPEND):
+            record("os.open", path)
+        return original_os_open(path, flags, *args, **kwargs)
+
+    def observed_os_replace(source: Any, destination: Any, *args: Any, **kwargs: Any) -> None:
+        record("replace", destination)
+        original_os_replace(source, destination, *args, **kwargs)
+
+    with (
+        patch.object(Path, "open", observed_path_open),
+        patch.object(Path, "write_text", observed_write_text),
+        patch.object(Path, "write_bytes", observed_write_bytes),
+        patch.object(builtins, "open", observed_builtin_open),
+        patch.object(os, "open", observed_os_open),
+        patch.object(os, "replace", observed_os_replace),
+    ):
+        yield writes
+
+
+def _run_unchanged_incremental(
+    config: AppConfig, provider: ReplayProvider
+) -> tuple[int, int, int]:
+    """Run unchanged production Compile and observe calls, writes, and final content."""
+    before = _owned_state_hashes(config)
+    calls_before = provider.call_count
+    with _observe_owned_state_writes(config) as writes:
+        _run_production_compile(config, provider)
+    after = _owned_state_hashes(config)
+    return (
+        _changed_hash_count(before, after),
+        provider.call_count - calls_before,
+        len(writes),
+    )
+
+
+def run_evaluation(
+    fixture_dir: Path = DEFAULT_FIXTURE_DIR,
+    *,
+    schema_path: Path = DEFAULT_SCHEMA_PATH,
+) -> EvaluationReport:
+    """Run the checked-in scenario in a temporary, network-disabled vault."""
+    scenario = load_scenario(fixture_dir / "corpus.json")
+    thresholds = load_thresholds(fixture_dir / "thresholds.json")
+    provider = ReplayProvider.from_path(fixture_dir / "replay.json")
+
+    with tempfile.TemporaryDirectory(prefix="vaultmind-evaluation-") as directory, _network_blocked():
+        config = _materialize_vault(Path(directory), scenario, schema_path)
+        calls_before = provider.call_count
+        _run_production_compile(config, provider)
+        if provider.call_count == calls_before:
+            raise EvaluationRunError("first corpus phase produced no provider calls")
+
+        probe = _inject_reconciliation_probe(config, scenario)
+        probe_results: list[str] | None = None
+        for phase in range(2, max(source.phase for source in scenario.sources) + 1):
+            _materialize_sources(config.vault_path, scenario, phase=phase)
+            calls_before = provider.call_count
+            if phase == 2:
+                with _observe_reconciliation_probe(config, probe) as observations:
+                    _run_production_compile(config, provider)
+                if not observations:
+                    raise EvaluationRunError("production compile did not reconcile manifest state")
+                # The first observation is the pre-compile reconciliation. Later
+                # article updates must not be allowed to mask a missed repair.
+                probe_results = observations[0]
+            else:
+                _run_production_compile(config, provider)
+            if provider.call_count == calls_before:
+                raise EvaluationRunError(f"corpus phase {phase} produced no provider calls")
+        if probe_results is None:
+            raise EvaluationRunError("reconciliation probe requires production compile phase 2")
+
+        query_pages = asyncio.run(_run_queries(config, scenario, provider))
+        lint_report = _run_lint(config)
+        incremental_changed, incremental_calls, incremental_writes = (
+            _run_unchanged_incremental(config, provider)
+        )
+
+        final_raw = scan_raw_sources(config)
+        final_manifest = read_manifest(config.vault_path)
+        concept_pages = _scan_concept_pages(config)
+        index_path = (
+            config.vault_path
+            / config.folders.wiki
+            / f"{config.folders.wiki_index}.md"
+        )
+        index_markdown = (
+            index_path.read_text(encoding="utf-8") if index_path.is_file() else None
+        )
+        metrics = calculate_metrics(
+            scenario=scenario,
+            raw_sources=final_raw,
+            manifest=final_manifest,
+            concept_pages=concept_pages,
+            lint_report=lint_report,
+            index_markdown=index_markdown,
+            query_pages=query_pages,
+            wiki_concepts_folder=config.folders.wiki_concepts,
+            wiki_queries_folder=config.folders.wiki_queries,
+            incremental_changed_file_count=incremental_changed,
+            incremental_owned_state_write_count=incremental_writes,
+            incremental_provider_call_count=incremental_calls,
+            reconciliation_probe_results=probe_results,
+            provider_call_count=provider.call_count,
+        )
+
+    failures = evaluate_thresholds(metrics, thresholds)
+    return EvaluationReport(
+        scenario=scenario.name,
+        threshold_set=thresholds.name,
+        metrics=metrics,
+        failures=failures,
+        passed=not failures,
+    )

--- a/tests/fixtures/evaluation/corpus.json
+++ b/tests/fixtures/evaluation/corpus.json
@@ -1,0 +1,329 @@
+{
+  "name": "representative-20-source-wiki",
+  "sources": [
+    {
+      "id": "source-01",
+      "title": "Retrieval Grounding Study 1",
+      "source_url": "https://evaluation.example/sources/01",
+      "tags": [
+        "retrieval-grounding",
+        "citation-provenance"
+      ],
+      "body": "Study 1 explains that retrieval grounding selects durable wiki evidence before Raw fallback. It also connects retrieval grounding with citation provenance, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-02",
+      "title": "Retrieval Grounding Study 2",
+      "source_url": "https://evaluation.example/sources/02",
+      "tags": [
+        "retrieval-grounding",
+        "citation-provenance"
+      ],
+      "body": "Study 2 explains that retrieval grounding selects durable wiki evidence before Raw fallback. It also connects retrieval grounding with citation provenance, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-03",
+      "title": "Retrieval Grounding Study 3",
+      "source_url": "https://evaluation.example/sources/03",
+      "tags": [
+        "retrieval-grounding",
+        "citation-provenance"
+      ],
+      "body": "Study 3 explains that retrieval grounding selects durable wiki evidence before Raw fallback. It also connects retrieval grounding with citation provenance, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-04",
+      "title": "Retrieval Grounding Study 4",
+      "source_url": "https://evaluation.example/sources/04",
+      "tags": [
+        "retrieval-grounding",
+        "citation-provenance"
+      ],
+      "body": "Study 4 explains that retrieval grounding selects durable wiki evidence before Raw fallback. It also connects retrieval grounding with citation provenance, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-05",
+      "title": "Retrieval Grounding Study 5",
+      "source_url": "https://evaluation.example/sources/05",
+      "tags": [
+        "retrieval-grounding",
+        "citation-provenance"
+      ],
+      "body": "Study 5 explains that retrieval grounding selects durable wiki evidence before Raw fallback. It also connects retrieval grounding with citation provenance, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 2
+    },
+    {
+      "id": "source-06",
+      "title": "Citation Provenance Study 1",
+      "source_url": "https://evaluation.example/sources/06",
+      "tags": [
+        "citation-provenance",
+        "knowledge-graphs"
+      ],
+      "body": "Study 1 explains that citation provenance keeps source and article references reciprocal. It also connects citation provenance with knowledge graphs, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-07",
+      "title": "Citation Provenance Study 2",
+      "source_url": "https://evaluation.example/sources/07",
+      "tags": [
+        "citation-provenance",
+        "knowledge-graphs"
+      ],
+      "body": "Study 2 explains that citation provenance keeps source and article references reciprocal. It also connects citation provenance with knowledge graphs, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-08",
+      "title": "Citation Provenance Study 3",
+      "source_url": "https://evaluation.example/sources/08",
+      "tags": [
+        "citation-provenance",
+        "knowledge-graphs"
+      ],
+      "body": "Study 3 explains that citation provenance keeps source and article references reciprocal. It also connects citation provenance with knowledge graphs, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-09",
+      "title": "Citation Provenance Study 4",
+      "source_url": "https://evaluation.example/sources/09",
+      "tags": [
+        "citation-provenance",
+        "knowledge-graphs"
+      ],
+      "body": "Study 4 explains that citation provenance keeps source and article references reciprocal. It also connects citation provenance with knowledge graphs, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-10",
+      "title": "Citation Provenance Study 5",
+      "source_url": "https://evaluation.example/sources/10",
+      "tags": [
+        "citation-provenance",
+        "knowledge-graphs"
+      ],
+      "body": "Study 5 explains that citation provenance keeps source and article references reciprocal. It also connects citation provenance with knowledge graphs, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 2
+    },
+    {
+      "id": "source-11",
+      "title": "Knowledge Graphs Study 1",
+      "source_url": "https://evaluation.example/sources/11",
+      "tags": [
+        "knowledge-graphs",
+        "incremental-compilation"
+      ],
+      "body": "Study 1 explains that knowledge graphs connect concepts through normalized wiki edges. It also connects knowledge graphs with incremental compilation, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-12",
+      "title": "Knowledge Graphs Study 2",
+      "source_url": "https://evaluation.example/sources/12",
+      "tags": [
+        "knowledge-graphs",
+        "incremental-compilation"
+      ],
+      "body": "Study 2 explains that knowledge graphs connect concepts through normalized wiki edges. It also connects knowledge graphs with incremental compilation, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-13",
+      "title": "Knowledge Graphs Study 3",
+      "source_url": "https://evaluation.example/sources/13",
+      "tags": [
+        "knowledge-graphs",
+        "incremental-compilation"
+      ],
+      "body": "Study 3 explains that knowledge graphs connect concepts through normalized wiki edges. It also connects knowledge graphs with incremental compilation, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-14",
+      "title": "Knowledge Graphs Study 4",
+      "source_url": "https://evaluation.example/sources/14",
+      "tags": [
+        "knowledge-graphs",
+        "incremental-compilation"
+      ],
+      "body": "Study 4 explains that knowledge graphs connect concepts through normalized wiki edges. It also connects knowledge graphs with incremental compilation, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-15",
+      "title": "Knowledge Graphs Study 5",
+      "source_url": "https://evaluation.example/sources/15",
+      "tags": [
+        "knowledge-graphs",
+        "incremental-compilation"
+      ],
+      "body": "Study 5 explains that knowledge graphs connect concepts through normalized wiki edges. It also connects knowledge graphs with incremental compilation, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 2
+    },
+    {
+      "id": "source-16",
+      "title": "Incremental Compilation Study 1",
+      "source_url": "https://evaluation.example/sources/16",
+      "tags": [
+        "incremental-compilation",
+        "retrieval-grounding"
+      ],
+      "body": "Study 1 explains that incremental compilation hashes Raw state and avoids unchanged writes. It also connects incremental compilation with retrieval grounding, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-17",
+      "title": "Incremental Compilation Study 2",
+      "source_url": "https://evaluation.example/sources/17",
+      "tags": [
+        "incremental-compilation",
+        "retrieval-grounding"
+      ],
+      "body": "Study 2 explains that incremental compilation hashes Raw state and avoids unchanged writes. It also connects incremental compilation with retrieval grounding, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-18",
+      "title": "Incremental Compilation Study 3",
+      "source_url": "https://evaluation.example/sources/18",
+      "tags": [
+        "incremental-compilation",
+        "retrieval-grounding"
+      ],
+      "body": "Study 3 explains that incremental compilation hashes Raw state and avoids unchanged writes. It also connects incremental compilation with retrieval grounding, so repeated sources should compound into shared concept pages rather than isolated summaries.",
+      "phase": 1
+    },
+    {
+      "id": "source-19",
+      "title": "Incremental Compilation Study 4",
+      "source_url": "https://evaluation.example/sources/19",
+      "tags": [
+        "incremental-compilation",
+        "retrieval-grounding"
+      ],
+      "body": "Study 4 explains that incremental compilation hashes Raw state and avoids unchanged writes. It also connects incremental compilation with retrieval grounding, so repeated sources should compound into shared concept pages rather than isolated summaries. A calibration ledger practice records unresolved evidence for direct Raw inspection.",
+      "phase": 1
+    },
+    {
+      "id": "source-20",
+      "title": "Incremental Compilation Study 5",
+      "source_url": "https://evaluation.example/sources/20",
+      "tags": [
+        "incremental-compilation",
+        "retrieval-grounding"
+      ],
+      "body": "Study 5 explains that incremental compilation hashes Raw state and avoids unchanged writes. It also connects incremental compilation with retrieval grounding, so repeated sources should compound into shared concept pages rather than isolated summaries. A calibration ledger practice records unresolved evidence for direct Raw inspection.",
+      "phase": 2
+    }
+  ],
+  "expected_concepts": [
+    {
+      "slug": "retrieval-grounding",
+      "title": "Retrieval Grounding",
+      "source_ids": [
+        "source-01",
+        "source-02",
+        "source-03",
+        "source-04",
+        "source-05"
+      ]
+    },
+    {
+      "slug": "citation-provenance",
+      "title": "Citation Provenance",
+      "source_ids": [
+        "source-06",
+        "source-07",
+        "source-08",
+        "source-09",
+        "source-10"
+      ]
+    },
+    {
+      "slug": "knowledge-graphs",
+      "title": "Knowledge Graphs",
+      "source_ids": [
+        "source-11",
+        "source-12",
+        "source-13",
+        "source-14",
+        "source-15"
+      ]
+    },
+    {
+      "slug": "incremental-compilation",
+      "title": "Incremental Compilation",
+      "source_ids": [
+        "source-16",
+        "source-17",
+        "source-18",
+        "source-19",
+        "source-20"
+      ]
+    }
+  ],
+  "expected_edges": [
+    {
+      "source": "retrieval-grounding",
+      "target": "citation-provenance"
+    },
+    {
+      "source": "retrieval-grounding",
+      "target": "incremental-compilation"
+    },
+    {
+      "source": "citation-provenance",
+      "target": "retrieval-grounding"
+    },
+    {
+      "source": "citation-provenance",
+      "target": "knowledge-graphs"
+    },
+    {
+      "source": "knowledge-graphs",
+      "target": "citation-provenance"
+    },
+    {
+      "source": "knowledge-graphs",
+      "target": "incremental-compilation"
+    },
+    {
+      "source": "incremental-compilation",
+      "target": "retrieval-grounding"
+    },
+    {
+      "source": "incremental-compilation",
+      "target": "knowledge-graphs"
+    }
+  ],
+  "queries": [
+    {
+      "question": "Retrieval Grounding",
+      "support": [
+        "concept"
+      ],
+      "reuses_filed_query": false
+    },
+    {
+      "question": "Retrieval Grounding Foundation",
+      "support": [
+        "concept",
+        "filed_query"
+      ],
+      "reuses_filed_query": true
+    },
+    {
+      "question": "Calibration ledger practice",
+      "support": [
+        "raw"
+      ],
+      "reuses_filed_query": false
+    }
+  ]
+}

--- a/tests/fixtures/evaluation/replay.json
+++ b/tests/fixtures/evaluation/replay.json
@@ -1,0 +1,242 @@
+{
+  "rules": [
+    {
+      "id": "compile-triage-initial",
+      "match": {
+        "prompt_contains": [
+          "Given the following RAW source documents",
+          "Source: https://evaluation.example/sources/01"
+        ],
+        "system_contains": [
+          "precise librarian"
+        ]
+      },
+      "responses": [
+        "{\"concepts\": [{\"name\": \"Retrieval Grounding\", \"status\": \"new\", \"description\": \"Retrieval uses compiled pages first and falls back to Raw only when durable wiki evidence is insufficient.\", \"source_urls\": [\"https://evaluation.example/sources/01\", \"https://evaluation.example/sources/02\", \"https://evaluation.example/sources/03\", \"https://evaluation.example/sources/04\"], \"merge_target\": null}, {\"name\": \"Citation Provenance\", \"status\": \"new\", \"description\": \"Reciprocal provenance makes every concept citation traceable through article and source manifest records.\", \"source_urls\": [\"https://evaluation.example/sources/06\", \"https://evaluation.example/sources/07\", \"https://evaluation.example/sources/08\", \"https://evaluation.example/sources/09\"], \"merge_target\": null}, {\"name\": \"Knowledge Graphs\", \"status\": \"new\", \"description\": \"Normalized wikilinks turn related concepts into a navigable graph whose expected relationships can be measured.\", \"source_urls\": [\"https://evaluation.example/sources/11\", \"https://evaluation.example/sources/12\", \"https://evaluation.example/sources/13\", \"https://evaluation.example/sources/14\"], \"merge_target\": null}, {\"name\": \"Incremental Compilation\", \"status\": \"new\", \"description\": \"Content hashes let unchanged Raw material produce a zero-call, zero-write incremental compilation.\", \"source_urls\": [\"https://evaluation.example/sources/16\", \"https://evaluation.example/sources/17\", \"https://evaluation.example/sources/18\", \"https://evaluation.example/sources/19\"], \"merge_target\": null}]}"
+      ]
+    },
+    {
+      "id": "compile-dedup-initial",
+      "match": {
+        "prompt_contains": [
+          "Concepts to deduplicate:",
+          "https://evaluation.example/sources/01"
+        ],
+        "system_contains": [
+          "precise librarian"
+        ]
+      },
+      "responses": [
+        "{\"concepts\": [{\"name\": \"Retrieval Grounding\", \"status\": \"new\", \"description\": \"Retrieval uses compiled pages first and falls back to Raw only when durable wiki evidence is insufficient.\", \"source_urls\": [\"https://evaluation.example/sources/01\", \"https://evaluation.example/sources/02\", \"https://evaluation.example/sources/03\", \"https://evaluation.example/sources/04\"], \"merge_target\": null}, {\"name\": \"Citation Provenance\", \"status\": \"new\", \"description\": \"Reciprocal provenance makes every concept citation traceable through article and source manifest records.\", \"source_urls\": [\"https://evaluation.example/sources/06\", \"https://evaluation.example/sources/07\", \"https://evaluation.example/sources/08\", \"https://evaluation.example/sources/09\"], \"merge_target\": null}, {\"name\": \"Knowledge Graphs\", \"status\": \"new\", \"description\": \"Normalized wikilinks turn related concepts into a navigable graph whose expected relationships can be measured.\", \"source_urls\": [\"https://evaluation.example/sources/11\", \"https://evaluation.example/sources/12\", \"https://evaluation.example/sources/13\", \"https://evaluation.example/sources/14\"], \"merge_target\": null}, {\"name\": \"Incremental Compilation\", \"status\": \"new\", \"description\": \"Content hashes let unchanged Raw material produce a zero-call, zero-write incremental compilation.\", \"source_urls\": [\"https://evaluation.example/sources/16\", \"https://evaluation.example/sources/17\", \"https://evaluation.example/sources/18\", \"https://evaluation.example/sources/19\"], \"merge_target\": null}]}"
+      ]
+    },
+    {
+      "id": "compile-triage-update",
+      "match": {
+        "prompt_contains": [
+          "Given the following RAW source documents",
+          "Source: https://evaluation.example/sources/20"
+        ],
+        "system_contains": [
+          "precise librarian"
+        ]
+      },
+      "responses": [
+        "{\"concepts\": [{\"name\": \"Retrieval Grounding\", \"status\": \"existing:retrieval-grounding\", \"description\": \"Retrieval uses compiled pages first and falls back to Raw only when durable wiki evidence is insufficient.\", \"source_urls\": [\"https://evaluation.example/sources/05\"], \"merge_target\": \"retrieval-grounding\"}, {\"name\": \"Citation Provenance\", \"status\": \"existing:citation-provenance\", \"description\": \"Reciprocal provenance makes every concept citation traceable through article and source manifest records.\", \"source_urls\": [\"https://evaluation.example/sources/10\"], \"merge_target\": \"citation-provenance\"}, {\"name\": \"Knowledge Graphs\", \"status\": \"existing:knowledge-graphs\", \"description\": \"Normalized wikilinks turn related concepts into a navigable graph whose expected relationships can be measured.\", \"source_urls\": [\"https://evaluation.example/sources/15\"], \"merge_target\": \"knowledge-graphs\"}, {\"name\": \"Incremental Compilation\", \"status\": \"existing:incremental-compilation\", \"description\": \"Content hashes let unchanged Raw material produce a zero-call, zero-write incremental compilation.\", \"source_urls\": [\"https://evaluation.example/sources/20\"], \"merge_target\": \"incremental-compilation\"}]}"
+      ]
+    },
+    {
+      "id": "compile-dedup-update",
+      "match": {
+        "prompt_contains": [
+          "Concepts to deduplicate:",
+          "https://evaluation.example/sources/20"
+        ],
+        "system_contains": [
+          "precise librarian"
+        ]
+      },
+      "responses": [
+        "{\"concepts\": [{\"name\": \"Retrieval Grounding\", \"status\": \"existing:retrieval-grounding\", \"description\": \"Retrieval uses compiled pages first and falls back to Raw only when durable wiki evidence is insufficient.\", \"source_urls\": [\"https://evaluation.example/sources/05\"], \"merge_target\": \"retrieval-grounding\"}, {\"name\": \"Citation Provenance\", \"status\": \"existing:citation-provenance\", \"description\": \"Reciprocal provenance makes every concept citation traceable through article and source manifest records.\", \"source_urls\": [\"https://evaluation.example/sources/10\"], \"merge_target\": \"citation-provenance\"}, {\"name\": \"Knowledge Graphs\", \"status\": \"existing:knowledge-graphs\", \"description\": \"Normalized wikilinks turn related concepts into a navigable graph whose expected relationships can be measured.\", \"source_urls\": [\"https://evaluation.example/sources/15\"], \"merge_target\": \"knowledge-graphs\"}, {\"name\": \"Incremental Compilation\", \"status\": \"existing:incremental-compilation\", \"description\": \"Content hashes let unchanged Raw material produce a zero-call, zero-write incremental compilation.\", \"source_urls\": [\"https://evaluation.example/sources/20\"], \"merge_target\": \"incremental-compilation\"}]}"
+      ]
+    },
+    {
+      "id": "article-create-retrieval-grounding",
+      "match": {
+        "prompt_contains": [
+          "concept \"Retrieval Grounding\"",
+          "Write a new, source-grounded wiki article"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Retrieval Grounding\n\n## Overview\n\nRetrieval uses compiled pages first and falls back to Raw only when durable wiki evidence is insufficient.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[citation-provenance]].\n- Related to [[incremental-compilation]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/01\n- https://evaluation.example/sources/02\n- https://evaluation.example/sources/03\n- https://evaluation.example/sources/04\n"
+      ]
+    },
+    {
+      "id": "article-update-retrieval-grounding",
+      "match": {
+        "prompt_contains": [
+          "You are maintaining a research wiki",
+          "title: Retrieval Grounding"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Retrieval Grounding\n\n## Overview\n\nRetrieval uses compiled pages first and falls back to Raw only when durable wiki evidence is insufficient.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[citation-provenance]].\n- Related to [[incremental-compilation]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/01\n- https://evaluation.example/sources/02\n- https://evaluation.example/sources/03\n- https://evaluation.example/sources/04\n- https://evaluation.example/sources/05\n"
+      ]
+    },
+    {
+      "id": "article-create-citation-provenance",
+      "match": {
+        "prompt_contains": [
+          "concept \"Citation Provenance\"",
+          "Write a new, source-grounded wiki article"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Citation Provenance\n\n## Overview\n\nReciprocal provenance makes every concept citation traceable through article and source manifest records.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[retrieval-grounding]].\n- Related to [[knowledge-graphs]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/06\n- https://evaluation.example/sources/07\n- https://evaluation.example/sources/08\n- https://evaluation.example/sources/09\n"
+      ]
+    },
+    {
+      "id": "article-update-citation-provenance",
+      "match": {
+        "prompt_contains": [
+          "You are maintaining a research wiki",
+          "title: Citation Provenance"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Citation Provenance\n\n## Overview\n\nReciprocal provenance makes every concept citation traceable through article and source manifest records.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[retrieval-grounding]].\n- Related to [[knowledge-graphs]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/06\n- https://evaluation.example/sources/07\n- https://evaluation.example/sources/08\n- https://evaluation.example/sources/09\n- https://evaluation.example/sources/10\n"
+      ]
+    },
+    {
+      "id": "article-create-knowledge-graphs",
+      "match": {
+        "prompt_contains": [
+          "concept \"Knowledge Graphs\"",
+          "Write a new, source-grounded wiki article"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Knowledge Graphs\n\n## Overview\n\nNormalized wikilinks turn related concepts into a navigable graph whose expected relationships can be measured.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[citation-provenance]].\n- Related to [[incremental-compilation]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/11\n- https://evaluation.example/sources/12\n- https://evaluation.example/sources/13\n- https://evaluation.example/sources/14\n"
+      ]
+    },
+    {
+      "id": "article-update-knowledge-graphs",
+      "match": {
+        "prompt_contains": [
+          "You are maintaining a research wiki",
+          "title: Knowledge Graphs"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Knowledge Graphs\n\n## Overview\n\nNormalized wikilinks turn related concepts into a navigable graph whose expected relationships can be measured.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[citation-provenance]].\n- Related to [[incremental-compilation]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/11\n- https://evaluation.example/sources/12\n- https://evaluation.example/sources/13\n- https://evaluation.example/sources/14\n- https://evaluation.example/sources/15\n"
+      ]
+    },
+    {
+      "id": "article-create-incremental-compilation",
+      "match": {
+        "prompt_contains": [
+          "concept \"Incremental Compilation\"",
+          "Write a new, source-grounded wiki article"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Incremental Compilation\n\n## Overview\n\nContent hashes let unchanged Raw material produce a zero-call, zero-write incremental compilation.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[retrieval-grounding]].\n- Related to [[knowledge-graphs]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/16\n- https://evaluation.example/sources/17\n- https://evaluation.example/sources/18\n- https://evaluation.example/sources/19\n"
+      ]
+    },
+    {
+      "id": "article-update-incremental-compilation",
+      "match": {
+        "prompt_contains": [
+          "You are maintaining a research wiki",
+          "title: Incremental Compilation"
+        ],
+        "system_contains": [
+          "research wiki author"
+        ]
+      },
+      "responses": [
+        "# Incremental Compilation\n\n## Overview\n\nContent hashes let unchanged Raw material produce a zero-call, zero-write incremental compilation.\n\n## Key Ideas\n\nThe representative studies overlap and reinforce one durable concept instead of producing one page per source. The persisted result remains grounded in explicit source citations.\n\n## Connections\n\n- Related to [[retrieval-grounding]].\n- Related to [[knowledge-graphs]].\n\n## Open Questions\n\n- How should maintainers govern quality thresholds as the fixture evolves?\n\n## Sources\n\n- https://evaluation.example/sources/16\n- https://evaluation.example/sources/17\n- https://evaluation.example/sources/18\n- https://evaluation.example/sources/19\n- https://evaluation.example/sources/20\n"
+      ]
+    },
+    {
+      "id": "index-rebuild",
+      "match": {
+        "prompt_contains": [
+          "Current wiki articles:",
+          "[[retrieval-grounding|Retrieval Grounding]]"
+        ],
+        "system_contains": [
+          "wiki index maintainer"
+        ]
+      },
+      "responses": [
+        "# Wiki Index\n\n- [[citation-provenance|Citation Provenance]] \u2014 reciprocal source traceability.\n- [[incremental-compilation|Incremental Compilation]] \u2014 stable hash-based updates.\n- [[knowledge-graphs|Knowledge Graphs]] \u2014 connected concept structure.\n- [[retrieval-grounding|Retrieval Grounding]] \u2014 wiki-first grounded retrieval.\n",
+        "# Wiki Index\n\n- [[citation-provenance|Citation Provenance]] \u2014 reciprocal source traceability.\n- [[incremental-compilation|Incremental Compilation]] \u2014 stable hash-based updates.\n- [[knowledge-graphs|Knowledge Graphs]] \u2014 connected concept structure.\n- [[retrieval-grounding|Retrieval Grounding]] \u2014 wiki-first grounded retrieval.\n"
+      ]
+    },
+    {
+      "id": "ask-1",
+      "match": {
+        "prompt_contains": [
+          "Question: Retrieval Grounding\n\nAccumulated context:"
+        ],
+        "system_contains": [
+          "iterative query synthesis engine"
+        ]
+      },
+      "responses": [
+        "{\"answer\": \"Compiled concept pages provide durable evidence before Raw fallback, with citations preserving traceability.\"}"
+      ]
+    },
+    {
+      "id": "ask-2",
+      "match": {
+        "prompt_contains": [
+          "Question: Retrieval Grounding Foundation\n\nAccumulated context:"
+        ],
+        "system_contains": [
+          "iterative query synthesis engine"
+        ]
+      },
+      "responses": [
+        "{\"answer\": \"The compiled retrieval concept and the previously filed answer reinforce a reusable wiki-first foundation.\"}"
+      ]
+    },
+    {
+      "id": "ask-3",
+      "match": {
+        "prompt_contains": [
+          "Question: Calibration ledger practice\n\nAccumulated context:"
+        ],
+        "system_contains": [
+          "iterative query synthesis engine"
+        ]
+      },
+      "responses": [
+        "{\"answer\": \"The Raw studies describe a calibration ledger as a way to record unresolved evidence for direct inspection.\"}"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/evaluation/thresholds.json
+++ b/tests/fixtures/evaluation/thresholds.json
@@ -1,0 +1,31 @@
+{
+  "name": "committed-offline-baseline-v1",
+  "thresholds": [
+    {"metric": "corpus_source_count", "minimum": 20, "maximum": 20},
+    {"metric": "scanned_source_count", "minimum": 20, "maximum": 20},
+    {"metric": "current_compiled_coverage", "minimum": 1.0},
+    {"metric": "concept_count", "minimum": 4, "maximum": 4},
+    {"metric": "expected_concept_recall", "minimum": 1.0},
+    {"metric": "expected_source_to_concept_attribution_recall", "minimum": 1.0},
+    {"metric": "unexpected_source_to_concept_attribution_count", "maximum": 0},
+    {"metric": "source_to_concept_attribution_precision", "minimum": 1.0},
+    {"metric": "suspicious_duplicate_pair_count", "maximum": 0},
+    {"metric": "citation_provenance_inconsistency_count", "maximum": 0},
+    {"metric": "expected_graph_edge_recall", "minimum": 1.0},
+    {"metric": "duplicate_connection_count", "maximum": 0},
+    {"metric": "index_present", "minimum": 1, "maximum": 1},
+    {"metric": "expected_concept_index_link_recall", "minimum": 1.0},
+    {"metric": "unexpected_index_link_count", "maximum": 0},
+    {"metric": "broken_wikilinks", "maximum": 0},
+    {"metric": "stale_manifest_findings", "maximum": 0},
+    {"metric": "lint_finding_count", "maximum": 0},
+    {"metric": "wiki_supported_query_rate", "minimum": 0.6666666666666666},
+    {"metric": "raw_fallback_count", "maximum": 1},
+    {"metric": "filed_query_reuse_count", "minimum": 1},
+    {"metric": "query_expectation_pass_rate", "minimum": 1.0},
+    {"metric": "incremental_changed_file_count", "maximum": 0},
+    {"metric": "incremental_owned_state_write_count", "maximum": 0},
+    {"metric": "incremental_provider_call_count", "maximum": 0},
+    {"metric": "reconciliation_probe_success_rate", "minimum": 1.0}
+  ]
+}

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,672 @@
+"""Rigorous integration and edge-case tests for the offline evaluation harness."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import shutil
+import socket
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from vaultmind.commands import compile as compile_command
+from vaultmind.core.linter import ConceptPage
+from vaultmind.core.manifest import ManifestReconciliation
+from vaultmind.core.raw_scanner import RawSourceRecord
+from vaultmind.evaluation import (
+    EvaluationThreshold,
+    EvaluationThresholds,
+    ExhaustedReplayResponseError,
+    ReplayFixture,
+    ReplayProvider,
+    ReplayRule,
+    UnmatchedReplayPromptError,
+    evaluate_thresholds,
+    render_report_json,
+    run_evaluation,
+)
+from vaultmind.evaluation.metrics import (
+    citation_inconsistencies,
+    graph_quality,
+    index_quality,
+    source_concept_attribution_quality,
+)
+from vaultmind.evaluation.models import EvaluationScenario
+from vaultmind.evaluation.replay import ReplayMatch
+from vaultmind.evaluation.runner import DEFAULT_FIXTURE_DIR, OfflineNetworkError, _network_blocked
+from vaultmind.schemas import Manifest, ManifestSource, ManifestWikiEntry
+
+
+def _fixture_hashes(path: Path) -> dict[str, str]:
+    return {
+        item.relative_to(path).as_posix(): hashlib.sha256(item.read_bytes()).hexdigest()
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    }
+
+
+async def test_replay_matches_rules_under_concurrency_and_is_rule_local() -> None:
+    provider = ReplayProvider(
+        ReplayFixture(
+            rules=[
+                ReplayRule(
+                    id="alpha",
+                    match=ReplayMatch(prompt_contains=["alpha"]),
+                    responses=["a1", "a2"],
+                ),
+                ReplayRule(
+                    id="beta",
+                    match=ReplayMatch(prompt_contains=["beta"]),
+                    responses=["b1"],
+                ),
+            ]
+        )
+    )
+
+    beta, alpha_one, alpha_two = await asyncio.gather(
+        provider.complete("request beta"),
+        provider.complete("request alpha"),
+        provider.complete("another alpha"),
+    )
+
+    assert beta == "b1"
+    assert {alpha_one, alpha_two} == {"a1", "a2"}
+    assert provider.consumed_by_rule == {"alpha": 2, "beta": 1}
+
+
+async def test_replay_rejects_unmatched_and_exhausted_without_prompt_disclosure() -> None:
+    secret_prompt = "private prompt body token=do-not-disclose"
+    provider = ReplayProvider(
+        ReplayFixture(
+            rules=[
+                ReplayRule(
+                    id="known",
+                    match=ReplayMatch(prompt_contains=["known"]),
+                    responses=["done"],
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(UnmatchedReplayPromptError) as unmatched:
+        await provider.complete(secret_prompt)
+    assert provider.call_count == 1
+    assert secret_prompt not in str(unmatched.value)
+    assert "prompt_sha256=" in str(unmatched.value)
+    assert len(str(unmatched.value)) < 200
+
+    assert await provider.complete("known") == "done"
+    assert provider.call_count == 2
+    with pytest.raises(ExhaustedReplayResponseError) as exhausted:
+        await provider.complete("known")
+    assert provider.call_count == 3
+    assert "known" not in str(exhausted.value).replace("rule=known", "")
+    assert len(str(exhausted.value)) < 220
+
+
+def test_index_metrics_use_normalized_real_wikilinks() -> None:
+    scenario = EvaluationScenario.model_validate(
+        {
+            "name": "index-edge-case",
+            "sources": [],
+            "expected_concepts": [
+                {"slug": "alpha", "title": "Alpha", "source_ids": []},
+                {"slug": "beta", "title": "Beta", "source_ids": []},
+            ],
+            "expected_edges": [],
+            "queries": [],
+        }
+    )
+    index_markdown = (
+        "# Index\n\n- [[🧠 Concepts/Alpha.md|Alpha]]\n"
+        "~~~markdown\n[[beta]]\n~~~\n"
+        "- [[stale-concept#Overview|Stale]]\n"
+    )
+
+    present, expected_count, recall, unexpected_count = index_quality(
+        index_markdown, scenario
+    )
+
+    assert present == 1
+    assert expected_count == 2
+    assert recall == 0.5
+    assert unexpected_count == 1
+
+
+def test_graph_metrics_ignore_fenced_edges_and_count_duplicate_connections() -> None:
+    scenario = EvaluationScenario.model_validate(
+        {
+            "name": "edge-case",
+            "sources": [],
+            "expected_concepts": [],
+            "expected_edges": [
+                {"source": "alpha", "target": "beta"},
+                {"source": "alpha", "target": "gamma"},
+            ],
+            "queries": [],
+        }
+    )
+    page = ConceptPage(
+        slug="alpha",
+        title="Alpha",
+        relative_path="Wiki/alpha",
+        sources=[],
+        text=(
+            "## Connections\n[[beta]] and [[beta|again]]\n"
+            "~~~markdown\n[[gamma]]\n~~~\n"
+        ),
+    )
+
+    recall, duplicates = graph_quality([page], scenario)
+
+    assert recall == 0.5
+    assert duplicates == 1
+
+
+def test_citation_metrics_check_both_manifest_directions_and_current_coverage() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    source = RawSourceRecord(
+        path=Path("Raw/source.md"),
+        relative_path="Raw/source",
+        title="Source",
+        source_url="https://example.test/source",
+        body="body",
+        content_hash="current",
+        raw_tags=[],
+    )
+    page = ConceptPage(
+        slug="alpha",
+        title="Alpha",
+        relative_path="Wiki/alpha",
+        sources=["https://example.test/source"],
+        text="# Alpha",
+    )
+    manifest = Manifest(
+        sources={
+            "https://example.test/source": ManifestSource(
+                content_hash="current",
+                saved_at=now,
+                wiki_articles=[],
+            )
+        },
+        wiki_articles={
+            "alpha": ManifestWikiEntry(
+                last_updated=now,
+                source_urls=[],
+                content_hash="hash",
+            )
+        },
+    )
+
+    findings = citation_inconsistencies([source], manifest, [page])
+
+    assert any(item.startswith("page_source_missing_manifest_article") for item in findings)
+    assert any(item.startswith("source_backlink_missing_article") for item in findings)
+
+
+def test_network_guard_rejects_socket_connections() -> None:
+    with _network_blocked(), pytest.raises(OfflineNetworkError):
+        socket.create_connection(("example.com", 443))
+
+
+def test_committed_fixture_shape_and_hygiene() -> None:
+    corpus = json.loads((DEFAULT_FIXTURE_DIR / "corpus.json").read_text(encoding="utf-8"))
+    fixture_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(DEFAULT_FIXTURE_DIR.glob("*.json"))
+    )
+
+    assert len(corpus["sources"]) == 20
+    assert len(corpus["expected_concepts"]) >= 4
+    assert all(len(concept["source_ids"]) >= 2 for concept in corpus["expected_concepts"])
+    assert corpus["expected_edges"]
+    assert not re.search(r"(?:/Users/|/home/|[A-Za-z]:\\\\)", fixture_text)
+    assert not re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}", fixture_text)
+    assert "api_key" not in fixture_text.lower()
+
+
+def test_complete_fixture_is_isolated_deterministic_and_passes() -> None:
+    before = _fixture_hashes(DEFAULT_FIXTURE_DIR)
+
+    first = run_evaluation()
+    second = run_evaluation()
+    first_json = render_report_json(first)
+
+    assert first.passed
+    assert first_json == render_report_json(second)
+    assert _fixture_hashes(DEFAULT_FIXTURE_DIR) == before
+    assert first.metrics.corpus_source_count == 20
+    assert first.metrics.scanned_source_count == 20
+    assert first.metrics.concept_count == 4
+    assert first.metrics.current_compiled_coverage == 1.0
+    assert first.metrics.expected_source_to_concept_attribution_recall == 1.0
+    assert first.metrics.unexpected_source_to_concept_attribution_count == 0
+    assert first.metrics.source_to_concept_attribution_precision == 1.0
+    assert first.metrics.expected_graph_edge_recall == 1.0
+    assert first.metrics.index_present == 1
+    assert first.metrics.expected_concept_index_link_recall == 1.0
+    assert first.metrics.unexpected_index_link_count == 0
+    assert first.metrics.reconciliation_probe_success_rate == 1.0
+    assert first.metrics.reconciliation_probe_results == [
+        "concept_hash:repaired",
+        "ghost_wiki_entry:repaired",
+        "source_back_reference:repaired",
+    ]
+    assert first.metrics.filed_query_reuse_count == 1
+    assert first.metrics.raw_fallback_count == 1
+    assert first.metrics.incremental_provider_call_count == 0
+    assert first.metrics.incremental_changed_file_count == 0
+    assert first.metrics.incremental_owned_state_write_count == 0
+    assert not re.search(r"(?:/Users/|/home/|/var/folders/|[A-Za-z]:\\\\)", first_json)
+    assert not re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}", first_json)
+    assert "/tmp/" not in first_json
+    assert "vaultmind-evaluation-" not in first_json
+    assert "api_key" not in first_json.lower()
+
+
+def test_evaluation_invokes_production_compile_for_each_phase_and_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    production_compile = compile_command._compile
+    invocations = 0
+
+    def observe_compile(*, full: bool, dry_run: bool, verbose: bool, max_touches: int) -> None:
+        nonlocal invocations
+        invocations += 1
+        production_compile(
+            full=full,
+            dry_run=dry_run,
+            verbose=verbose,
+            max_touches=max_touches,
+        )
+
+    monkeypatch.setattr(compile_command, "_compile", observe_compile)
+
+    report = run_evaluation()
+
+    assert report.passed
+    assert invocations == 3
+
+
+@pytest.mark.parametrize("mutation", ["missing", "incomplete"])
+def test_index_rebuild_mutations_fail_the_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    production_rebuild = compile_command._rebuild_wiki_index
+
+    if mutation == "missing":
+        monkeypatch.setattr(
+            compile_command,
+            "_rebuild_wiki_index",
+            lambda config, manifest, provider: None,
+        )
+    else:
+        def incomplete_rebuild(config, manifest, provider) -> None:  # type: ignore[no-untyped-def]
+            production_rebuild(config, manifest, provider)
+            index_path = (
+                config.vault_path
+                / config.folders.wiki
+                / f"{config.folders.wiki_index}.md"
+            )
+            retained = [
+                line
+                for line in index_path.read_text(encoding="utf-8").splitlines()
+                if "[[retrieval-grounding" not in line
+            ]
+            index_path.write_text("\n".join(retained) + "\n", encoding="utf-8")
+
+        monkeypatch.setattr(compile_command, "_rebuild_wiki_index", incomplete_rebuild)
+
+    report = run_evaluation()
+
+    assert not report.passed
+    failure_metrics = {failure.metric for failure in report.failures}
+    expected_failure = (
+        "index_present"
+        if mutation == "missing"
+        else "expected_concept_index_link_recall"
+    )
+    assert expected_failure in failure_metrics
+
+
+def test_disabled_production_reconciliation_fails_the_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def no_reconciliation(manifest, *, concepts_dir, current_raw_keys):  # type: ignore[no-untyped-def]
+        return ManifestReconciliation(
+            manifest=manifest,
+            repairs=(),
+            concept_membership_changed=False,
+        )
+
+    monkeypatch.setattr(compile_command, "reconcile_manifest", no_reconciliation)
+
+    report = run_evaluation()
+
+    assert not report.passed
+    assert report.metrics.reconciliation_probe_success_rate < 1.0
+    assert report.metrics.reconciliation_probe_results == [
+        "concept_hash:unrepaired",
+        "ghost_wiki_entry:unrepaired",
+        "source_back_reference:unrepaired",
+    ]
+    assert "reconciliation_probe_success_rate" in {
+        failure.metric for failure in report.failures
+    }
+
+
+def test_selectively_disabled_hash_reconciliation_fails_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    production_reconcile = compile_command.reconcile_manifest
+
+    def skip_hash_repair(manifest, *, concepts_dir, current_raw_keys):  # type: ignore[no-untyped-def]
+        result = production_reconcile(
+            manifest,
+            concepts_dir=concepts_dir,
+            current_raw_keys=current_raw_keys,
+        )
+        slug = "citation-provenance"
+        entry = result.manifest.wiki_articles.get(slug)
+        if entry is not None and "reconciliation-probe-ghost" in manifest.wiki_articles:
+            result.manifest.wiki_articles[slug] = entry.model_copy(
+                update={"content_hash": "reconciliation-probe-incorrect-hash"}
+            )
+        return result
+
+    monkeypatch.setattr(compile_command, "reconcile_manifest", skip_hash_repair)
+
+    report = run_evaluation()
+
+    assert not report.passed
+    assert report.metrics.reconciliation_probe_results == [
+        "concept_hash:unrepaired",
+        "ghost_wiki_entry:repaired",
+        "source_back_reference:repaired",
+    ]
+    assert "reconciliation_probe_success_rate" in {
+        failure.metric for failure in report.failures
+    }
+
+
+def test_unchanged_compile_counts_caught_unmatched_provider_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    production_compile = compile_command._compile
+    invocation = 0
+
+    def attempt_unmatched(*, full: bool, dry_run: bool, verbose: bool, max_touches: int) -> None:
+        nonlocal invocation
+        invocation += 1
+        if invocation == 3:
+            config = compile_command.load_config()
+            provider = compile_command.get_provider(config, tier="deep")
+            with pytest.raises(UnmatchedReplayPromptError):
+                asyncio.run(provider.complete("deliberately unmatched incremental request"))
+        production_compile(
+            full=full,
+            dry_run=dry_run,
+            verbose=verbose,
+            max_touches=max_touches,
+        )
+
+    monkeypatch.setattr(compile_command, "_compile", attempt_unmatched)
+
+    report = run_evaluation()
+
+    assert report.metrics.incremental_provider_call_count == 1
+    assert "incremental_provider_call_count" in {
+        failure.metric for failure in report.failures
+    }
+
+
+def test_unchanged_compile_detects_same_byte_owned_state_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    production_compile = compile_command._compile
+
+    def rewrite_manifest(*, full: bool, dry_run: bool, verbose: bool, max_touches: int) -> None:
+        production_compile(
+            full=full,
+            dry_run=dry_run,
+            verbose=verbose,
+            max_touches=max_touches,
+        )
+        manifest_path = compile_command.load_config().vault_path / "vault.manifest.json"
+        if manifest_path.exists():
+            manifest_path.write_bytes(manifest_path.read_bytes())
+
+    monkeypatch.setattr(compile_command, "_compile", rewrite_manifest)
+
+    report = run_evaluation()
+
+    assert report.metrics.incremental_changed_file_count == 0
+    assert report.metrics.incremental_owned_state_write_count > 0
+    assert "incremental_owned_state_write_count" in {
+        failure.metric for failure in report.failures
+    }
+
+
+def test_cyclic_wrong_source_concept_attribution_fails_quality_bounds() -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    source_one = "https://example.test/one"
+    source_two = "https://example.test/two"
+    scenario = EvaluationScenario.model_validate(
+        {
+            "name": "wrong-attribution",
+            "sources": [
+                {
+                    "id": "one",
+                    "title": "One",
+                    "source_url": source_one,
+                    "body": "one",
+                },
+                {
+                    "id": "two",
+                    "title": "Two",
+                    "source_url": source_two,
+                    "body": "two",
+                },
+            ],
+            "expected_concepts": [
+                {"slug": "alpha", "title": "Alpha", "source_ids": ["one"]},
+                {"slug": "beta", "title": "Beta", "source_ids": ["two"]},
+            ],
+            "expected_edges": [],
+            "queries": [],
+        }
+    )
+    pages = [
+        ConceptPage("alpha", "Alpha", "Wiki/alpha", [source_two], "# Alpha"),
+        ConceptPage("beta", "Beta", "Wiki/beta", [source_one], "# Beta"),
+    ]
+    manifest = Manifest(
+        sources={
+            source_one: ManifestSource(
+                content_hash="one", saved_at=now, wiki_articles=["beta"]
+            ),
+            source_two: ManifestSource(
+                content_hash="two", saved_at=now, wiki_articles=["alpha"]
+            ),
+        },
+        wiki_articles={
+            "alpha": ManifestWikiEntry(
+                last_updated=now, source_urls=[source_two], content_hash="alpha"
+            ),
+            "beta": ManifestWikiEntry(
+                last_updated=now, source_urls=[source_one], content_hash="beta"
+            ),
+        },
+    )
+
+    expected_count, recall, unexpected_count, precision = (
+        source_concept_attribution_quality(scenario, manifest, pages)
+    )
+
+    assert expected_count == 2
+    assert recall == 0.0
+    assert unexpected_count == 2
+    assert precision == 0.0
+
+    metrics = run_evaluation().metrics.model_copy(
+        update={
+            "expected_source_to_concept_attribution_recall": recall,
+            "unexpected_source_to_concept_attribution_count": unexpected_count,
+            "source_to_concept_attribution_precision": precision,
+        }
+    )
+    failures = evaluate_thresholds(
+        metrics,
+        EvaluationThresholds(
+            name="attribution-bounds",
+            thresholds=[
+                EvaluationThreshold(
+                    metric="expected_source_to_concept_attribution_recall", minimum=1.0
+                ),
+                EvaluationThreshold(
+                    metric="unexpected_source_to_concept_attribution_count", maximum=0
+                ),
+                EvaluationThreshold(
+                    metric="source_to_concept_attribution_precision", minimum=1.0
+                ),
+            ],
+        ),
+    )
+    assert [failure.metric for failure in failures] == [
+        "expected_source_to_concept_attribution_recall",
+        "source_to_concept_attribution_precision",
+        "unexpected_source_to_concept_attribution_count",
+    ]
+
+
+def test_threshold_evaluation_aggregates_all_failures_deterministically() -> None:
+    metrics = run_evaluation().metrics.model_copy(
+        update={"current_compiled_coverage": 0.25, "broken_wikilinks": 3}
+    )
+    thresholds = EvaluationThresholds(
+        name="deliberate-failure",
+        thresholds=[
+            EvaluationThreshold(metric="current_compiled_coverage", minimum=1.0),
+            EvaluationThreshold(metric="broken_wikilinks", maximum=0),
+            EvaluationThreshold(metric="concept_count", minimum=1),
+        ],
+    )
+
+    failures = evaluate_thresholds(metrics, thresholds)
+
+    assert [failure.metric for failure in failures] == [
+        "broken_wikilinks",
+        "current_compiled_coverage",
+    ]
+
+
+def test_check_fails_for_stale_index_lint_finding(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture"
+    shutil.copytree(DEFAULT_FIXTURE_DIR, fixture)
+    replay_path = fixture / "replay.json"
+    replay_data = json.loads(replay_path.read_text(encoding="utf-8"))
+    index_rule = next(rule for rule in replay_data["rules"] if rule["id"] == "index-rebuild")
+    index_rule["responses"] = [
+        response + "\n- [[deleted-concept]] — stale.\n"
+        for response in index_rule["responses"]
+    ]
+    replay_path.write_text(json.dumps(replay_data), encoding="utf-8")
+    output = tmp_path / "stale-index-report.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/evaluate_fixture.py",
+            "--fixture-dir",
+            str(fixture),
+            "--output",
+            str(output),
+            "--check",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["metrics"]["lint_finding_count"] == 1
+    assert report["metrics"]["unexpected_index_link_count"] == 1
+    failure_metrics = {failure["metric"] for failure in report["failures"]}
+    assert "lint_finding_count" in failure_metrics
+    assert "unexpected_index_link_count" in failure_metrics
+
+
+def test_cli_writes_safe_report_when_evaluation_raises(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture"
+    shutil.copytree(DEFAULT_FIXTURE_DIR, fixture)
+    replay_path = fixture / "replay.json"
+    replay_path.write_text('{"rules": []}', encoding="utf-8")
+    output = tmp_path / "error-report.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/evaluate_fixture.py",
+            "--fixture-dir",
+            str(fixture),
+            "--output",
+            str(output),
+            "--check",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 2
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report == {
+        "schema_version": 1,
+        "passed": False,
+        "error_type": "EvaluationRunError",
+        "error_fingerprint": hashlib.sha256(b"EvaluationRunError").hexdigest()[:24],
+    }
+    serialized = output.read_text(encoding="utf-8")
+    assert str(tmp_path) not in serialized
+    assert "prompt" not in serialized.lower()
+
+
+def test_check_writes_report_before_nonzero_exit(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture"
+    shutil.copytree(DEFAULT_FIXTURE_DIR, fixture)
+    threshold_path = fixture / "thresholds.json"
+    threshold_data = json.loads(threshold_path.read_text(encoding="utf-8"))
+    threshold_data["thresholds"].append(
+        {"metric": "expected_graph_edge_recall", "minimum": 2.0}
+    )
+    threshold_path.write_text(json.dumps(threshold_data), encoding="utf-8")
+    output = tmp_path / "failed-report.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/evaluate_fixture.py",
+            "--fixture-dir",
+            str(fixture),
+            "--output",
+            str(output),
+            "--check",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 1
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert not report["passed"]
+    assert [failure["metric"] for failure in report["failures"]] == [
+        "expected_graph_edge_recall"
+    ]


### PR DESCRIPTION
## Summary

- add a deterministic 20-source offline corpus and prompt-matched replay provider
- exercise production Compile create/update/reconciliation/index paths, Ask filing/reuse/Raw fallback, and Lint
- measure source coverage, expected attribution, citation integrity, graph/index recall, duplicates, query support, lint health, and incremental stability
- inject and verify deterministic reconciliation drift repairs
- count actual owned-state write attempts and every provider attempt during unchanged compilation
- emit stable success, threshold-failure, and safe execution-error JSON reports
- gate quality thresholds in CI and retain the report even on evaluation failure

## Baseline

- 20/20 current sources compiled
- 4 expected concepts
- 100% expected source-to-concept attribution recall
- 100% expected graph and index recall
- zero provenance, lint, duplicate-link, or stale-state findings
- filed-query reuse and intentional Raw fallback exercised
- zero provider attempts, writes, or changed state on unchanged incremental compile

## Verification

```text
uv run ruff check
uv run mypy src/vaultmind
uv run pytest
uv run python scripts/evaluate_fixture.py --output evaluation-report.json --check
uv build
```

246 tests and the committed evaluation baseline pass.
