### PR TITLE
Prepare VaultMind v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.2.1 - 2026-07-14
 
 ### Added
 
-- First-class OpenRouter runtime and setup support, including independent credentials, configurable OpenAI-compatible endpoints, model slugs, and ordered fallback diagnostics.
+- First-class OpenRouter support through `vm init` and ordered runtime fallback, with its own `OPENROUTER_API_KEY`, the default or a configurable OpenAI-compatible endpoint, and configurable model slugs.
 
 ## 0.2.0 - 2026-07-12
 

--- a/README.md
+++ b/README.md
@@ -284,16 +284,16 @@ See `vm <command> --help` for all flags.
 
 ## Installation
 
-The current source and GitHub release version is 0.2.0. Check that PyPI lists it,
+The current source and GitHub release version is 0.2.1. Check that PyPI lists it,
 then install and verify the isolated CLI:
 
 ```bash
 python -m pip index versions vaultmind
-pipx install vaultmind==0.2.0
-vm version  # VaultMind v0.2.0
+pipx install vaultmind==0.2.1
+vm version  # VaultMind v0.2.1
 ```
 
-If PyPI does not list 0.2.0 yet, follow the authorized manual publication procedure
+If PyPI does not list 0.2.1 yet, follow the authorized manual publication procedure
 rather than installing from an unverified artifact. Or run from this repository:
 
 ```bash
@@ -316,7 +316,7 @@ setup, protected-environment approval, release verification, and recovery guidan
 
 The config stores vault paths, folder names, and AI provider preferences. The `.env` stores API keys.
 
-### Runtime provider fallback (v0.2.0)
+### Runtime provider fallback (v0.2.1)
 
 VaultMind supports Anthropic, OpenAI, OpenRouter, and local Ollama at runtime.
 Every completion follows `ai.fallback_chain` in order. VaultMind constructs all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vaultmind"
-version = "0.2.0"
+version = "0.2.1"
 description = "Clip anything into Obsidian. Run vm compile. Ask your living wiki."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vaultmind/__init__.py
+++ b/src/vaultmind/__init__.py
@@ -1,3 +1,3 @@
 """VaultMind — a local-first CLI for an LLM-maintained Obsidian wiki."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -17,16 +17,16 @@ from vaultmind.main import app
 def test_package_and_runtime_versions_are_consistent() -> None:
     project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
 
-    assert project["version"] == "0.2.0"
-    assert __version__ == "0.2.0"
-    assert version("vaultmind") == "0.2.0"
+    assert project["version"] == "0.2.1"
+    assert __version__ == "0.2.1"
+    assert version("vaultmind") == "0.2.1"
 
 
 def test_vm_version_reports_release_version() -> None:
     result = CliRunner().invoke(app, ["version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "VaultMind v0.2.0"
+    assert result.stdout.strip() == "VaultMind v0.2.1"
 
 
 def _workflow(path: str) -> dict[str, Any]:
@@ -79,7 +79,7 @@ def test_ci_preserves_quality_build_and_dynamic_wheel_smoke() -> None:
     assert "pyproject.toml" in smoke
     assert "tomllib" in smoke
     assert "EXPECTED_VERSION" in smoke
-    assert "VaultMind v0.2.0" not in smoke
+    assert "VaultMind v0.2.1" not in smoke
 
 
 def test_publish_workflow_has_release_and_required_manual_triggers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -804,7 +804,7 @@ wheels = [
 
 [[package]]
 name = "vaultmind"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- set package, runtime, test, and lock metadata to v0.2.1
- finalize v0.2.1 release notes for first-class OpenRouter support
- update installation and runtime-provider documentation
- preserve all dependency versions, provider behavior, and publishing policy

## Validation
- `uv lock --check`
- `uv run ruff check`
- `uv run mypy src/vaultmind`
- `uv run pytest` (254 passed)
- `uv run python scripts/evaluate_fixture.py --output evaluation-report.json --check`
- `uv build`
- isolated install of `dist/vaultmind-0.2.1-py3-none-any.whl`
- installed `vm version` exactly `VaultMind v0.2.1`
- adversarial release review: PASS
