### PR TITLE
Retry interrupted wiki index rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Interrupted Wiki index rebuilds are naturally retried by the next incremental compile without recompiling already-current Raw sources.
+
 ## 0.2.1 - 2026-07-14
 
 ### Added

--- a/src/vaultmind/commands/compile.py
+++ b/src/vaultmind/commands/compile.py
@@ -21,6 +21,7 @@ import yaml
 from vaultmind.ai.compiler import CompileResult, compile_sources, rebuild_index
 from vaultmind.ai.providers import Provider, ProviderExhaustedError, get_provider
 from vaultmind.config import AppConfig, load_config
+from vaultmind.core.linter import extract_wikilinks
 from vaultmind.core.manifest import (
     ManifestReadError,
     ManifestReconciliation,
@@ -38,7 +39,7 @@ from vaultmind.core.writer import write_markdown_page
 from vaultmind.schemas import Manifest, ManifestSource
 from vaultmind.utils.display import print_error, print_info, print_success, print_warning
 from vaultmind.utils.hashing import content_hash
-from vaultmind.utils.logging import setup_logging
+from vaultmind.utils.logging import setup_buffered_logging, setup_logging
 
 __all__ = ["reconcile_manifest"]
 
@@ -54,6 +55,32 @@ def _validate_max_touches(value: int) -> int:
 
 def _concepts_dir(config: AppConfig) -> Path:
     return config.vault_path / config.folders.wiki / config.folders.wiki_concepts
+
+
+def _wiki_index_is_incomplete(config: AppConfig, manifest: Manifest) -> bool:
+    """Return whether the index omits any disk-canonical manifest concept."""
+    if not manifest.wiki_articles:
+        return False
+
+    concepts_dir = _concepts_dir(config)
+    expected_slugs = {
+        slug.strip().lower()
+        for slug in manifest.wiki_articles
+        if (concepts_dir / f"{slug}.md").is_file()
+    }
+    if not expected_slugs:
+        return False
+
+    index_path = (
+        config.vault_path
+        / config.folders.wiki
+        / f"{config.folders.wiki_index}.md"
+    )
+    if not index_path.is_file():
+        return True
+
+    linked_slugs = set(extract_wikilinks(index_path.read_text(encoding="utf-8")))
+    return not expected_slugs.issubset(linked_slugs)
 
 
 def _report_reconciliation(
@@ -72,8 +99,6 @@ def _report_reconciliation(
 def _persist_repairs(
     config: AppConfig,
     reconciliation: ManifestReconciliation,
-    *,
-    provider: Provider | None,
 ) -> None:
     if not reconciliation.changed:
         return
@@ -83,8 +108,6 @@ def _persist_repairs(
         event="manifest repair",
         detail=f"{len(reconciliation.repairs)} repair(s)",
     )
-    if reconciliation.concept_membership_changed and provider is not None:
-        _rebuild_wiki_index(config, reconciliation.manifest, provider)
 
 
 def compile(
@@ -117,7 +140,17 @@ def compile(
 
 def _compile(*, full: bool, dry_run: bool, verbose: bool, max_touches: int) -> None:
     """Implement compile while the CLI boundary handles provider exhaustion."""
-    setup_logging(verbose=verbose)
+    preflight_logs = setup_buffered_logging()
+    logging_enabled = False
+
+    def enable_logging() -> None:
+        nonlocal logging_enabled
+        if logging_enabled:
+            return
+        setup_logging(verbose=verbose)
+        preflight_logs.replay()
+        logging_enabled = True
+
     config = load_config()
 
     try:
@@ -139,13 +172,28 @@ def _compile(*, full: bool, dry_run: bool, verbose: bool, max_touches: int) -> N
     )
     manifest = pre_reconciliation.manifest
     _report_reconciliation(pre_reconciliation, dry_run=dry_run)
+    index_rebuild_needed = (
+        pre_reconciliation.concept_membership_changed
+        or _wiki_index_is_incomplete(config, manifest)
+    )
 
     if not all_sources:
-        if not dry_run:
-            _persist_repairs(config, pre_reconciliation, provider=None)
-            if pre_reconciliation.concept_membership_changed:
+        if dry_run:
+            if index_rebuild_needed:
+                print_success(
+                    "Dry run",
+                    "No Raw sources would be compiled. Incomplete Wiki index would be rebuilt.",
+                )
+        else:
+            if pre_reconciliation.changed or index_rebuild_needed:
+                enable_logging()
+            _persist_repairs(config, pre_reconciliation)
+            if index_rebuild_needed:
                 provider = get_provider(config, tier="deep")
                 _rebuild_wiki_index(config, manifest, provider)
+                print_success(
+                    "Wiki index repaired", "No Raw sources needed compilation."
+                )
         print_warning(
             f"No raw sources found in {config.folders.raw}/. "
             "Add articles via Obsidian Web Clipper first."
@@ -172,19 +220,28 @@ def _compile(*, full: bool, dry_run: bool, verbose: bool, max_touches: int) -> N
 
     if not sources_to_compile:
         if dry_run:
-            print_success("Dry run", "No Raw sources would be compiled.")
-        elif pre_reconciliation.changed:
-            repair_provider = (
-                get_provider(config, tier="deep")
-                if pre_reconciliation.concept_membership_changed
-                else None
-            )
-            _persist_repairs(config, pre_reconciliation, provider=repair_provider)
-            print_success("Manifest repaired", "No Raw sources needed compilation.")
+            message = "No Raw sources would be compiled."
+            if index_rebuild_needed:
+                message += " Incomplete Wiki index would be rebuilt."
+            print_success("Dry run", message)
         else:
-            print_success("All sources are up to date", "Nothing to compile.")
+            if pre_reconciliation.changed or index_rebuild_needed:
+                enable_logging()
+            _persist_repairs(config, pre_reconciliation)
+            if index_rebuild_needed:
+                repair_provider = get_provider(config, tier="deep")
+                _rebuild_wiki_index(config, manifest, repair_provider)
+                print_success(
+                    "Wiki index repaired", "No Raw sources needed compilation."
+                )
+            elif pre_reconciliation.changed:
+                print_success("Manifest repaired", "No Raw sources needed compilation.")
+            else:
+                print_success("All sources are up to date", "Nothing to compile.")
         return
 
+    if not dry_run:
+        enable_logging()
     provider = get_provider(config, tier="deep")
     result, slug_to_urls = asyncio.run(
         _run_compile_async(

--- a/src/vaultmind/utils/logging.py
+++ b/src/vaultmind/utils/logging.py
@@ -7,9 +7,48 @@ Structured logs go to file. Debug mode sends human-readable logs to stderr.
 from __future__ import annotations
 
 import sys
+from collections.abc import MutableMapping
 from pathlib import Path
+from typing import Any, NoReturn
 
 import structlog
+
+
+class BufferedLogs:
+    """Capture preflight events in memory until a command confirms real work."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def capture(
+        self,
+        _logger: Any,
+        method_name: str,
+        event_dict: MutableMapping[str, Any],
+    ) -> NoReturn:
+        self.events.append((method_name, dict(event_dict)))
+        raise structlog.DropEvent
+
+    def replay(self) -> None:
+        """Replay captured events through the currently configured logger."""
+        events, self.events = self.events, []
+        logger = structlog.get_logger()
+        for method_name, event_dict in events:
+            event = event_dict.pop("event", "")
+            method = getattr(logger, method_name, logger.info)
+            method(event, **event_dict)
+
+
+def setup_buffered_logging() -> BufferedLogs:
+    """Replace any prior logger with a write-free in-memory preflight buffer."""
+    buffered = BufferedLogs()
+    structlog.configure(
+        processors=[buffered.capture],
+        wrapper_class=structlog.make_filtering_bound_logger(0),
+        logger_factory=structlog.ReturnLoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+    return buffered
 
 
 def setup_logging(verbose: bool = False) -> None:

--- a/tests/test_commands/test_compile.py
+++ b/tests/test_commands/test_compile.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+import structlog
 import typer
 
 from vaultmind.ai.providers.base import FailureKind, ProviderAttempt, ProviderExhaustedError
@@ -39,6 +40,49 @@ def _raw_source(
         body=f"# {slug}\n\nBody text",
         content_hash=f"hash-{slug}",
         raw_tags=[],
+    )
+
+
+def _seed_durable_compile_state(test_config, source, slugs=("concept-a", "concept-b")):
+    concepts_dir = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+    )
+    concepts_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    wiki_articles = {}
+    for slug in slugs:
+        sources = f"sources:\n  - {source.source_url}\n" if source is not None else ""
+        article = concepts_dir / f"{slug}.md"
+        article.write_text(
+            f"---\ntitle: {slug.replace('-', ' ').title()}\n{sources}---\n\n# {slug}\n",
+            encoding="utf-8",
+        )
+        wiki_articles[slug] = ManifestWikiEntry(
+            last_updated=now,
+            source_urls=[source.source_url] if source is not None else [],
+            content_hash=content_hash(article.read_text(encoding="utf-8")),
+        )
+
+    sources = {}
+    if source is not None:
+        sources[source.source_url] = ManifestSource(
+            content_hash=source.content_hash,
+            saved_at=now,
+            compiled_at=now,
+            wiki_articles=list(slugs),
+        )
+    manifest = Manifest(sources=sources, wiki_articles=wiki_articles)
+    write_manifest(test_config.vault_path, manifest)
+    return manifest
+
+
+def _index_path(test_config):
+    return (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / f"{test_config.folders.wiki_index}.md"
     )
 
 
@@ -131,6 +175,9 @@ def test_compile_repair_only_persists_without_provider_for_hash_repairs(
         f"---\nsources:\n  - {source.source_url}\n---\n\n# Concept A\n",
         encoding="utf-8",
     )
+    index_path = _index_path(test_config)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text("# Wiki Index\n\n- [[concept-a]]\n", encoding="utf-8")
     now = datetime.now(UTC)
     write_manifest(
         test_config.vault_path,
@@ -1059,6 +1106,299 @@ def test_compile_verbose_preserves_provider_exception_chain(monkeypatch):
         compile_cmd.compile(full=False, dry_run=False, verbose=True, max_touches=5)
 
     assert exc_info.value.__cause__ is cause
+
+
+def test_interrupted_index_rebuild_retries_without_recompiling_durable_sources(
+    monkeypatch, test_config
+):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    compile_runs = 0
+    rebuild_runs = 0
+    successes: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_info", lambda message: None)
+    monkeypatch.setattr(compile_cmd, "print_warning", lambda message: None)
+    monkeypatch.setattr(
+        compile_cmd,
+        "print_success",
+        lambda title, message: successes.append((title, message)),
+    )
+
+    async def durable_compile(sources, manifest, config, provider, dry_run, **kwargs):
+        nonlocal compile_runs
+        del sources, provider, dry_run, kwargs
+        compile_runs += 1
+        durable = _seed_durable_compile_state(
+            config,
+            source,
+            slugs=("concept-a", "concept-b", "concept-c", "concept-d"),
+        )
+        manifest.sources = durable.sources
+        manifest.wiki_articles = durable.wiki_articles
+        return compile_cmd.CompileResult(4, 0, 1, []), {
+            slug: [source.source_url] for slug in durable.wiki_articles
+        }
+
+    def interrupted_then_success(config, manifest, provider):
+        nonlocal rebuild_runs
+        del provider
+        rebuild_runs += 1
+        if rebuild_runs == 1:
+            raise _provider_exhausted()
+        links = "\n".join(f"- [[{slug}]]" for slug in manifest.wiki_articles)
+        _index_path(config).write_text(f"# Wiki Index\n\n{links}\n", encoding="utf-8")
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", durable_compile)
+    monkeypatch.setattr(compile_cmd, "_rebuild_wiki_index", interrupted_then_success)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        compile_cmd.compile(full=False, dry_run=False, verbose=False, max_touches=5)
+    assert exc_info.value.exit_code == 1
+    assert compile_runs == 1
+    assert not _index_path(test_config).exists()
+    durable_source = read_manifest(test_config.vault_path).sources[source.source_url]
+
+    compile_cmd.compile(full=False, dry_run=False, verbose=False, max_touches=5)
+
+    assert compile_runs == 1
+    assert rebuild_runs == 2
+    assert read_manifest(test_config.vault_path).sources[source.source_url] == durable_source
+    assert set(compile_cmd.extract_wikilinks(_index_path(test_config).read_text())) == {
+        "concept-a",
+        "concept-b",
+        "concept-c",
+        "concept-d",
+    }
+    assert successes[-1][0] == "Wiki index repaired"
+    assert all(title != "All sources are up to date" for title, _message in successes)
+
+
+def test_compile_repairs_incomplete_index_using_normalized_wikilinks(
+    monkeypatch, test_config
+):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    _seed_durable_compile_state(test_config, source)
+    index_path = _index_path(test_config)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        "# Wiki Index\n\n- [[🗺️ Wiki/🧠 Concepts/CONCEPT-A.md#Overview|Concept A]]\n",
+        encoding="utf-8",
+    )
+    rebuilds = 0
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_success", lambda title, message: None)
+
+    async def must_not_compile(*args, **kwargs):
+        raise AssertionError("durable Raw source must not be recompiled")
+
+    def rebuild(config, manifest, provider):
+        nonlocal rebuilds
+        del provider
+        rebuilds += 1
+        _index_path(config).write_text(
+            "# Wiki Index\n\n- [[concept-a]]\n- [[concept-b]]\n", encoding="utf-8"
+        )
+
+    monkeypatch.setattr(compile_cmd, "_run_compile_async", must_not_compile)
+    monkeypatch.setattr(compile_cmd, "_rebuild_wiki_index", rebuild)
+
+    compile_cmd.compile(full=False, dry_run=False, verbose=False, max_touches=5)
+
+    assert rebuilds == 1
+    assert set(compile_cmd.extract_wikilinks(index_path.read_text())) == {
+        "concept-a",
+        "concept-b",
+    }
+
+
+def test_compile_repeated_index_repair_failure_stays_retryable(monkeypatch, test_config):
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    _seed_durable_compile_state(test_config, source)
+    index_path = _index_path(test_config)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    original = b"# Wiki Index\n\n- [[concept-a]]\n"
+    index_path.write_bytes(original)
+    attempts = 0
+
+    monkeypatch.setattr(compile_cmd, "setup_logging", lambda verbose=False: None)
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_error", lambda message: None)
+
+    def fail_rebuild(config, manifest, provider):
+        nonlocal attempts
+        del config, manifest, provider
+        attempts += 1
+        raise _provider_exhausted()
+
+    monkeypatch.setattr(compile_cmd, "_rebuild_wiki_index", fail_rebuild)
+
+    for _ in range(2):
+        with pytest.raises(typer.Exit) as exc_info:
+            compile_cmd.compile(full=False, dry_run=False, verbose=False, max_touches=5)
+        assert exc_info.value.exit_code == 1
+        assert index_path.read_bytes() == original
+
+    assert attempts == 2
+
+
+def test_compile_complete_normalized_index_is_true_noop(monkeypatch, test_config):
+    app_home = test_config.vault_path.parent / f"{test_config.vault_path.name}-app-home"
+    app_log = app_home / ".local" / "share" / "vaultmind" / "vaultmind.log"
+    app_log.parent.mkdir(parents=True)
+    original_log = b'{"event":"previous command"}\n'
+    app_log.write_bytes(original_log)
+    stale_log_handle = open(app_log, "a", encoding="utf-8")  # noqa: SIM115
+    structlog.configure(
+        processors=[structlog.processors.JSONRenderer()],
+        logger_factory=structlog.PrintLoggerFactory(file=stale_log_handle),
+    )
+    monkeypatch.setenv("HOME", str(app_home))
+
+    raw_dir = test_config.vault_path / test_config.folders.raw
+    raw_dir.mkdir(parents=True)
+    raw_body = "# raw-a\n\nBody text"
+    raw_path = raw_dir / "raw-a.md"
+    raw_path.write_text(
+        "---\nsource: https://example.com/raw-a\n---\n\n" + raw_body,
+        encoding="utf-8",
+    )
+    source = RawSourceRecord(
+        path=raw_path,
+        relative_path=f"{test_config.folders.raw}/raw-a",
+        title="raw-a",
+        source_url="https://example.com/raw-a",
+        body=raw_body,
+        content_hash=content_hash(raw_body),
+        raw_tags=[],
+    )
+    _seed_durable_compile_state(test_config, source)
+    index_path = _index_path(test_config)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        "# Wiki Index\n\n"
+        "- [[🗺️ Wiki/🧠 Concepts/CONCEPT-A.md#Overview|Concept A]]\n"
+        "- [[Concept-B^details|Concept B]]\n",
+        encoding="utf-8",
+    )
+    before = {
+        path.relative_to(test_config.vault_path): path.read_bytes()
+        for path in test_config.vault_path.rglob("*")
+        if path.is_file()
+    }
+    successes: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(
+        compile_cmd,
+        "get_provider",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("provider not needed")),
+    )
+    monkeypatch.setattr(
+        compile_cmd,
+        "print_success",
+        lambda title, message: successes.append((title, message)),
+    )
+
+    try:
+        compile_cmd.compile(full=False, dry_run=False, verbose=False, max_touches=5)
+    finally:
+        stale_log_handle.close()
+
+    after = {
+        path.relative_to(test_config.vault_path): path.read_bytes()
+        for path in test_config.vault_path.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    assert app_log.read_bytes() == original_log
+    assert successes == [("All sources are up to date", "Nothing to compile.")]
+
+
+def test_compile_dry_run_reports_index_repair_without_provider_or_writes(
+    monkeypatch, test_config
+):
+    app_home = test_config.vault_path.parent / f"{test_config.vault_path.name}-app-home"
+    app_state = app_home / ".local" / "share" / "vaultmind"
+    monkeypatch.setenv("HOME", str(app_home))
+    source = _raw_source(slug="raw-a", source_url="https://example.com/raw-a")
+    _seed_durable_compile_state(test_config, source)
+    before = {
+        path.relative_to(test_config.vault_path): path.read_bytes()
+        for path in test_config.vault_path.rglob("*")
+        if path.is_file()
+    }
+    successes: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "scan_raw_sources", lambda config: [source])
+    monkeypatch.setattr(
+        compile_cmd,
+        "get_provider",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("dry run provider call")),
+    )
+    monkeypatch.setattr(
+        compile_cmd,
+        "print_success",
+        lambda title, message: successes.append((title, message)),
+    )
+
+    compile_cmd.compile(full=False, dry_run=True, verbose=False, max_touches=5)
+
+    after = {
+        path.relative_to(test_config.vault_path): path.read_bytes()
+        for path in test_config.vault_path.rglob("*")
+        if path.is_file()
+    }
+    assert after == before
+    assert not app_state.exists()
+    assert successes == [
+        ("Dry run", "No Raw sources would be compiled. Incomplete Wiki index would be rebuilt.")
+    ]
+
+
+def test_compile_repairs_missing_index_without_raw_sources(monkeypatch, test_config):
+    app_home = test_config.vault_path.parent / f"{test_config.vault_path.name}-app-home"
+    app_log = app_home / ".local" / "share" / "vaultmind" / "vaultmind.log"
+    monkeypatch.setenv("HOME", str(app_home))
+    _seed_durable_compile_state(test_config, source=None, slugs=("concept-a",))
+    rebuilds = 0
+    successes: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compile_cmd, "load_config", lambda: test_config)
+    monkeypatch.setattr(compile_cmd, "get_provider", lambda config, tier="deep": object())
+    monkeypatch.setattr(compile_cmd, "print_warning", lambda message: None)
+    monkeypatch.setattr(
+        compile_cmd,
+        "print_success",
+        lambda title, message: successes.append((title, message)),
+    )
+
+    def rebuild(config, manifest, provider):
+        nonlocal rebuilds
+        del provider
+        rebuilds += 1
+        _index_path(config).parent.mkdir(parents=True, exist_ok=True)
+        _index_path(config).write_text("# Wiki Index\n\n- [[concept-a]]\n", encoding="utf-8")
+
+    monkeypatch.setattr(compile_cmd, "_rebuild_wiki_index", rebuild)
+
+    compile_cmd.compile(full=False, dry_run=False, verbose=False, max_touches=5)
+
+    assert rebuilds == 1
+    assert _index_path(test_config).is_file()
+    assert app_log.is_file()
+    assert "raw_folder_missing" in app_log.read_text(encoding="utf-8")
+    assert successes == [("Wiki index repaired", "No Raw sources needed compilation.")]
 
 
 def test_index_rebuild_propagates_provider_exhaustion_without_writing(test_config):

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -296,8 +296,17 @@ def test_evaluation_invokes_production_compile_for_each_phase_and_unchanged(
 @pytest.mark.parametrize("mutation", ["missing", "incomplete"])
 def test_index_rebuild_mutations_fail_the_evaluation(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     mutation: str,
 ) -> None:
+    fixture = tmp_path / "evaluation"
+    shutil.copytree(DEFAULT_FIXTURE_DIR, fixture)
+    replay_path = fixture / "replay.json"
+    replay = json.loads(replay_path.read_text(encoding="utf-8"))
+    index_rule = next(rule for rule in replay["rules"] if rule["id"] == "index-rebuild")
+    index_rule["responses"].append(index_rule["responses"][-1])
+    replay_path.write_text(json.dumps(replay, indent=2) + "\n", encoding="utf-8")
+
     production_rebuild = compile_command._rebuild_wiki_index
 
     if mutation == "missing":
@@ -323,7 +332,7 @@ def test_index_rebuild_mutations_fail_the_evaluation(
 
         monkeypatch.setattr(compile_command, "_rebuild_wiki_index", incomplete_rebuild)
 
-    report = run_evaluation()
+    report = run_evaluation(fixture)
 
     assert not report.passed
     failure_metrics = {failure.metric for failure in report.failures}


### PR DESCRIPTION
## Summary
- detect missing or incomplete index coverage against disk-canonical manifest concepts
- repair the index on a later incremental compile without recompiling current Raw sources
- preserve retryability when the repair provider fails repeatedly
- buffer preflight structured logs in memory and persist them only when real work occurs
- keep complete no-ops and dry runs provider-free and write-free
- adapt only the temporary adversarial evaluation mutation fixture for the additional repair attempt

## Real-world failure fixed
A source compiled into four durable concept pages and manifest provenance, then a transient OpenRouter failure interrupted index rebuilding. The next v0.2.1 run incorrectly reported all sources current while `📇 Index.md` remained missing. This PR makes that next run perform an index-only repair.

## Validation
- `uv run ruff check`
- `uv run mypy src/vaultmind`
- `uv run pytest` (260 passed)
- `uv run python scripts/evaluate_fixture.py --output evaluation-report.json --check`
- offline unchanged phase: 0 provider calls, 0 writes, 0 changed files
