### PR TITLE
Validate generated article wikilinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Generated concept articles now preserve only wikilinks to approved concept pages that existed on disk before compilation, degrading invented targets to readable text before atomic create or update writes.
+
 ## 0.2.2 - 2026-07-15
 
 ### Fixed

--- a/src/vaultmind/ai/compiler.py
+++ b/src/vaultmind/ai/compiler.py
@@ -35,7 +35,7 @@ from vaultmind.ai.prompts import (
 )
 from vaultmind.ai.providers.base import Provider
 from vaultmind.config import FolderConfig
-from vaultmind.core.linter import extract_wikilinks
+from vaultmind.core.linter import extract_wikilinks, iter_markdown_regions
 from vaultmind.core.raw_scanner import RawSourceRecord, format_raw_source_packet
 from vaultmind.core.writer import write_markdown_page
 from vaultmind.schemas import ConceptStatus, Manifest, WikiConceptEntry
@@ -257,6 +257,14 @@ async def compile_sources(
     # clipped without a source URL are keyed by their vault-relative path.
     url_to_source = {_source_key(source): source for source in sources}
 
+    # Freeze the article-link allowlist before triage. Concepts proposed later
+    # in this run are deliberately ineligible, including concurrent siblings.
+    approved_concept_slugs = frozenset(
+        slug.strip().lower()
+        for slug, _title in (existing_concepts or [])
+        if slug.strip()
+    )
+
     # Stage 1: concept triage — uses RAW source content, not AI summaries
     log.info("compile_triage_start", count=len(sources))
     sources_payload = "\n\n---\n\n".join(format_raw_source_packet(s) for s in sources)
@@ -310,7 +318,13 @@ async def compile_sources(
                 log.info("compile_dry_run_create", concept=concept.name)
                 return (slug, slug, False, False, concept.source_urls)
             await _create_and_write_article(
-                slug, concept, url_to_source, provider, vault_path, folders
+                slug,
+                concept,
+                url_to_source,
+                provider,
+                vault_path,
+                folders,
+                approved_concept_slugs,
             )
             log.info("compile_article_done", slug=slug, status="created")
             return (slug, slug, True, False, concept.source_urls)
@@ -337,12 +351,19 @@ async def compile_sources(
                 provider,
                 vault_path,
                 folders,
+                approved_concept_slugs,
             )
             log.info("compile_article_done", slug=target_slug, status="updated")
             return (slug, target_slug, False, True, accepted_sources)
         else:
             await _create_and_write_article(
-                target_slug, concept, url_to_source, provider, vault_path, folders
+                target_slug,
+                concept,
+                url_to_source,
+                provider,
+                vault_path,
+                folders,
+                approved_concept_slugs,
             )
             log.info("compile_article_done", slug=target_slug, status="created_new")
             return (slug, target_slug, True, False, concept.source_urls)
@@ -405,8 +426,30 @@ ARTICLE_EXISTING_CONTENT_CHARS = 24000
 ARTICLE_PROMPT_TOTAL_CHARS = 50000
 ARTICLE_DESCRIPTION_CHARS = 4000
 ARTICLE_CONCEPT_NAME_CHARS = 500
+ARTICLE_CONCEPT_ALLOWLIST_LIMIT = 200
+ARTICLE_CONCEPT_ALLOWLIST_CHARS = 4000
 _SOURCE_LABEL_CHARS = 256
 _SOURCE_PACKET_MIN_CHARS = 96
+
+
+def _format_approved_concept_allowlist(approved_concept_slugs: set[str] | frozenset[str]) -> str:
+    """Return a deterministic, injection-safe, bounded prompt allowlist."""
+    normalized = sorted(
+        {slug.strip().lower() for slug in approved_concept_slugs if slug.strip()}
+    )
+    if not normalized:
+        return "No concept slugs are approved. Do not use any Obsidian wikilinks."
+
+    retained: list[str] = []
+    for slug in normalized[:ARTICLE_CONCEPT_ALLOWLIST_LIMIT]:
+        candidate = json.dumps([*retained, slug], ensure_ascii=False)
+        if len(candidate) > ARTICLE_CONCEPT_ALLOWLIST_CHARS:
+            break
+        retained.append(slug)
+
+    if not retained:
+        return "No concept slugs are approved. Do not use any Obsidian wikilinks."
+    return json.dumps(retained, ensure_ascii=False)
 
 
 def _bounded_source_references(
@@ -577,14 +620,20 @@ async def _create_article(
     concept: WikiConceptEntry,
     url_to_source: dict[str, RawSourceRecord],
     provider: Provider,
+    *,
+    approved_concept_slugs: set[str] | frozenset[str] | None = None,
 ) -> str:
     """LLM call to create a new wiki article from grounded Raw sources."""
     concept_name = _truncate_with_marker(concept.name, ARTICLE_CONCEPT_NAME_CHARS)
     description = _truncate_with_marker(concept.description, ARTICLE_DESCRIPTION_CHARS)
+    approved_concepts = _format_approved_concept_allowlist(
+        approved_concept_slugs or set()
+    )
     prompt_without_sources = COMPILE_ARTICLE_CREATE_PROMPT.format(
         concept_name=concept_name,
         description=description,
         source_context="",
+        approved_existing_concepts=approved_concepts,
     )
     source_context = _format_article_source_context(
         concept.source_urls,
@@ -595,6 +644,7 @@ async def _create_article(
         concept_name=concept_name,
         description=description,
         source_context=source_context,
+        approved_existing_concepts=approved_concepts,
     )
     assert len(prompt) <= ARTICLE_PROMPT_TOTAL_CHARS
 
@@ -608,6 +658,8 @@ async def _update_article(
     concept: WikiConceptEntry,
     url_to_source: dict[str, RawSourceRecord],
     provider: Provider,
+    *,
+    approved_concept_slugs: set[str] | frozenset[str] | None = None,
 ) -> str:
     """LLM call to update an existing wiki article with new source info."""
     bounded_existing = _truncate_with_marker(
@@ -615,9 +667,13 @@ async def _update_article(
         ARTICLE_EXISTING_CONTENT_CHARS,
         "\n\n[Existing article truncated]",
     )
+    approved_concepts = _format_approved_concept_allowlist(
+        approved_concept_slugs or set()
+    )
     prompt_without_sources = COMPILE_ARTICLE_UPDATE_PROMPT.format(
         existing_content=bounded_existing,
         new_sources="",
+        approved_existing_concepts=approved_concepts,
     )
     source_context = _format_article_source_context(
         concept.source_urls,
@@ -627,6 +683,7 @@ async def _update_article(
     prompt = COMPILE_ARTICLE_UPDATE_PROMPT.format(
         existing_content=bounded_existing,
         new_sources=source_context,
+        approved_existing_concepts=approved_concepts,
     )
     assert len(prompt) <= ARTICLE_PROMPT_TOTAL_CHARS
 
@@ -642,10 +699,29 @@ async def _create_and_write_article(
     provider: Provider,
     vault_path: Path,
     folders: FolderConfig,
+    approved_concept_slugs: set[str] | frozenset[str],
 ) -> None:
     """Create a wiki article via LLM and write it to disk."""
-    body = await _create_article(concept, url_to_source, provider)
-    _write_wiki_article(slug, body, concept.name, concept.source_urls, vault_path, folders)
+    body = await _create_article(
+        concept,
+        url_to_source,
+        provider,
+        approved_concept_slugs=approved_concept_slugs,
+    )
+    safe_title = _sanitize_article_title(
+        concept.name,
+        slug.replace("-", " ").title(),
+        approved_concept_slugs,
+    )
+    _write_wiki_article(
+        slug,
+        body,
+        safe_title,
+        concept.source_urls,
+        vault_path,
+        folders,
+        approved_concept_slugs,
+    )
 
 
 async def _update_and_write_article(
@@ -656,15 +732,30 @@ async def _update_and_write_article(
     provider: Provider,
     vault_path: Path,
     folders: FolderConfig,
+    approved_concept_slugs: set[str] | frozenset[str],
 ) -> None:
     """Update a wiki article via LLM and write it to disk."""
-    body = await _update_article(existing_content, concept, url_to_source, provider)
+    body = await _update_article(
+        existing_content,
+        concept,
+        url_to_source,
+        provider,
+        approved_concept_slugs=approved_concept_slugs,
+    )
     title = (
         _extract_frontmatter_title(existing_content)
         or _extract_h1_title(existing_content)
         or slug.replace("-", " ").title()
     )
-    _write_wiki_article(slug, body, title, concept.source_urls, vault_path, folders)
+    _write_wiki_article(
+        slug,
+        body,
+        title,
+        concept.source_urls,
+        vault_path,
+        folders,
+        approved_concept_slugs,
+    )
 
 
 REQUIRED_CONCEPT_SECTIONS = (
@@ -806,6 +897,87 @@ def _normalize_concept_body(body: str, title: str, sources: list[str]) -> str:
     return f"# {_single_line_title(title)}\n\n{model_content}"
 
 
+_WIKILINK_PATTERN = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def _wikilink_fallback(inner: str) -> str:
+    """Render an unauthorized wikilink as its readable alias or target label."""
+    target, separator, display = inner.partition("|")
+    if separator and display.strip():
+        return display.strip()
+
+    label = re.sub(r"[#^].*$", "", target).strip()
+    if label.endswith(".md"):
+        label = label[:-3]
+    if "/" in label:
+        label = label.rsplit("/", 1)[-1]
+    return label.strip()
+
+
+def _sanitize_wikilink_region(region: str, approved: set[str]) -> str:
+    """Sanitize a Markdown region known to be outside fenced code."""
+    # One or more removed wrappers can expose another [[...]] token. The
+    # strict length decrease gives a simple progress bound even for
+    # adversarial nesting and bracket adjacency.
+    max_passes = len(region) // 4 + 1
+    for _ in range(max_passes):
+        replacements = 0
+
+        def replace_link(match: re.Match[str]) -> str:
+            nonlocal replacements
+            normalized = extract_wikilinks(match.group(0))
+            if normalized and normalized[0] in approved:
+                return match.group(0)
+            replacements += 1
+            return _wikilink_fallback(match.group(1))
+
+        next_region = _WIKILINK_PATTERN.sub(replace_link, region)
+        if replacements == 0:
+            return region
+        if len(next_region) >= len(region):  # pragma: no cover - invariant guard
+            raise RuntimeError("wikilink sanitization did not make progress")
+        region = next_region
+
+    raise RuntimeError(  # pragma: no cover - implied by the strict length decrease
+        "wikilink sanitization exceeded its progress bound"
+    )
+
+
+def _sanitize_article_wikilinks(
+    body: str,
+    approved_concept_slugs: set[str] | frozenset[str],
+) -> str:
+    """Preserve only approved wikilinks outside fenced code regions."""
+    approved = {
+        slug.strip().lower() for slug in approved_concept_slugs if slug.strip()
+    }
+    sanitized = [
+        region if is_fenced else _sanitize_wikilink_region(region, approved)
+        for region, is_fenced in iter_markdown_regions(body)
+    ]
+
+    result = "".join(sanitized)
+    if set(extract_wikilinks(result)) - approved:  # pragma: no cover - invariant guard
+        raise RuntimeError("wikilink sanitization left an unauthorized target")
+    return result
+
+
+def _sanitize_article_title(
+    title: str,
+    fallback: str,
+    approved_concept_slugs: set[str] | frozenset[str],
+) -> str:
+    """Collapse and sanitize an untrusted model-authored article title."""
+    approved = {
+        slug.strip().lower() for slug in approved_concept_slugs if slug.strip()
+    }
+    single_line = _single_line_title(title, fallback)
+    # A title is inline text, never a fenced region, even if it starts with a
+    # fence marker before being placed in YAML or after the generated H1.
+    sanitized = _sanitize_wikilink_region(single_line, approved)
+    return _single_line_title(sanitized, fallback)
+
+
 def _write_wiki_article(
     slug: str,
     body: str,
@@ -813,6 +985,7 @@ def _write_wiki_article(
     source_urls: list[str],
     vault_path: Path,
     folders: FolderConfig,
+    approved_concept_slugs: set[str] | frozenset[str],
 ) -> None:
     """Write a wiki article to disk with frontmatter and atomic write."""
     wiki_concepts_dir = vault_path / folders.wiki / folders.wiki_concepts
@@ -825,7 +998,8 @@ def _write_wiki_article(
         context=f"page:{slug}",
     )
     safe_title = _single_line_title(title, slug.replace("-", " ").title())
-    content_body = _normalize_concept_body(body, safe_title, accepted_sources)
+    safe_body = _sanitize_article_wikilinks(body, approved_concept_slugs)
+    content_body = _normalize_concept_body(safe_body, safe_title, accepted_sources)
     import yaml
 
     class _IndentedSafeDumper(yaml.SafeDumper):

--- a/src/vaultmind/ai/prompts.py
+++ b/src/vaultmind/ai/prompts.py
@@ -65,6 +65,9 @@ Description: {description}
 Attributed citations and bounded Raw source packets:
 {source_context}
 
+Approved existing concept slugs (bounded to pages present before this compile):
+{approved_existing_concepts}
+
 Contract and rules:
 - Base factual content only on the supplied Raw packets; mark uncertainty when a cited source is unavailable
 - Be 400-800 words
@@ -72,7 +75,8 @@ Contract and rules:
 - Include every section exactly as an H2: Overview, Key Ideas, Connections, Open Questions, Sources
 - List every attributed source citation once as a bullet under Sources, including unresolved source keys
 - Be written in an encyclopedic but accessible tone
-- Use Obsidian wikilinks for related concepts where appropriate (e.g. [[attention-mechanisms]])
+- Only use wikilinks whose target canonically matches a slug in the approved existing concept list above; preserve aliases, paths, headings, or block references only for those approved targets
+- If no concept slugs are approved, do not use any Obsidian wikilinks
 - Do NOT repeat exact quotes from sources — synthesize in your own words
 
 Write the article in full markdown. No frontmatter. No code blocks unless showing code.
@@ -89,6 +93,9 @@ Existing article (possibly truncated by the caller):
 Attributed citations and new Raw source packets:
 {new_sources}
 
+Approved existing concept slugs (bounded to pages present before this compile):
+{approved_existing_concepts}
+
 Contract and rules:
 - Base new factual content only on the supplied Raw packets; mark uncertainty when a cited source is unavailable
 - Preserve useful existing content while incorporating all relevant new information
@@ -96,7 +103,8 @@ Contract and rules:
 - Include every section exactly as an H2: Overview, Key Ideas, Connections, Open Questions, Sources
 - List every attributed source citation once as a bullet under Sources, including unresolved source keys
 - Maintain consistent structure and tone with the existing article
-- Add Obsidian wikilinks to related concepts where appropriate (e.g. [[attention-mechanisms]])
+- Only use wikilinks whose target canonically matches a slug in the approved existing concept list above; preserve aliases, paths, headings, or block references only for those approved targets
+- If no concept slugs are approved, do not use any Obsidian wikilinks
 - Be 400-800 words unless the new sources substantially expand the topic
 - Do NOT repeat exact quotes — synthesize in your own words
 

--- a/src/vaultmind/core/linter.py
+++ b/src/vaultmind/core/linter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import difflib
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
@@ -77,41 +78,87 @@ class LintReport:
         return self.error_count > 0
 
 
+def iter_markdown_regions(text: str) -> Iterator[tuple[str, bool]]:
+    """Yield contiguous Markdown regions as ``(text, is_fenced_code)``.
+
+    This is the shared CommonMark fence contract for generated-article
+    sanitization and canonical Lint extraction: fences use backticks or
+    tildes, open with at least three markers after up to three spaces, and
+    close only with the same marker in a run at least as long as the opener.
+    """
+    region: list[str] = []
+    region_is_fenced = False
+    fence_char: str | None = None
+    fence_length = 0
+
+    for line in text.splitlines(keepends=True):
+        if line.endswith("\r\n"):
+            line_text = line[:-2]
+        elif line.endswith(("\n", "\r")):
+            line_text = line[:-1]
+        else:
+            line_text = line
+        is_fenced = fence_char is not None
+
+        if fence_char is None:
+            opener = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", line_text)
+            if opener:
+                marker, remainder = opener.groups()
+                # CommonMark forbids backticks in a backtick fence info string.
+                if marker[0] == "~" or "`" not in remainder:
+                    fence_char = marker[0]
+                    fence_length = len(marker)
+                    is_fenced = True
+        else:
+            closer = re.fullmatch(
+                rf" {{0,3}}({re.escape(fence_char)}+)[ \t]*", line_text
+            )
+            if closer and len(closer.group(1)) >= fence_length:
+                fence_char = None
+                fence_length = 0
+
+        if region and is_fenced != region_is_fenced:
+            yield "".join(region), region_is_fenced
+            region = []
+        region.append(line)
+        region_is_fenced = is_fenced
+
+    if region:
+        yield "".join(region), region_is_fenced
+
+
 def extract_wikilinks(text: str) -> list[str]:
-    """Extract and normalize wikilinks from text.
+    """Extract and normalize wikilinks outside CommonMark fenced code.
 
     Handles [[target]], [[target|display]], paths, heading refs, block refs.
-    Ignores links inside fenced code blocks.
     Returns lowercased basenames.
     """
-    # Remove fenced code blocks
-    text_without_code = re.sub(r'```[\s\S]*?```', '', text)
-
-    # Find all wikilinks: [[...]]
-    pattern = r'\[\[([^\]]+)\]\]'
-    matches = re.findall(pattern, text_without_code)
-
+    pattern = re.compile(r"\[\[([^\]]+)\]\]")
     normalized = []
-    for match in matches:
-        # Split on | to get target part (before display text)
-        target = match.split('|')[0].strip()
 
-        # Remove heading and block refs
-        target = re.sub(r'[#^].*$', '', target).strip()
+    for region, is_fenced in iter_markdown_regions(text):
+        if is_fenced:
+            continue
+        for match in pattern.findall(region):
+            # Split on | to get target part (before display text)
+            target = match.split("|")[0].strip()
 
-        # Remove trailing .md
-        if target.endswith('.md'):
-            target = target[:-3]
+            # Remove heading and block refs
+            target = re.sub(r"[#^].*$", "", target).strip()
 
-        # Take the last path segment (basename)
-        if '/' in target:
-            target = target.split('/')[-1]
+            # Remove trailing .md
+            if target.endswith(".md"):
+                target = target[:-3]
 
-        # Lowercase and strip
-        target = target.strip().lower()
+            # Take the last path segment (basename)
+            if "/" in target:
+                target = target.split("/")[-1]
 
-        if target:
-            normalized.append(target)
+            # Lowercase and strip
+            target = target.strip().lower()
+
+            if target:
+                normalized.append(target)
 
     return normalized
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -23,12 +23,14 @@ from vaultmind.ai.compiler import (
     _format_article_source_context,
     _markdown_h2_sections,
     _normalize_concept_body,
+    _sanitize_article_wikilinks,
     _split_page,
     _strip_frontmatter_block,
     _strip_model_page_wrappers,
     compile_sources,
 )
 from vaultmind.commands.compile import _run_compile_async
+from vaultmind.core.linter import WikiPage, check_broken_wikilinks, extract_wikilinks
 from vaultmind.core.manifest import read_manifest
 from vaultmind.core.raw_scanner import RawSourceRecord, scan_raw_sources
 from vaultmind.schemas import ConceptStatus, Manifest, WikiConceptEntry
@@ -490,6 +492,349 @@ Second source note.
     assert "Second source note." in normalized
     outside_fence = normalized[normalized.index("```", normalized.index("```") + 3) + 3 :]
     assert outside_fence.count(f"- {source}") == 1
+
+
+def test_article_wikilink_sanitizer_preserves_canonical_approved_forms_and_fences():
+    body = (
+        "Keep [[Approved]], [[Wiki/Concepts/APPROVED.md#Heading|Shown]], "
+        "[[approved^block]], [[approved.md]], and [[approved|Alias]].\n"
+        "Drop [[invented]], [[path/invented.md#Heading]], [[invented^block]], "
+        "and [[invented|Display Text]] while keeping sibling [[approved]].\n\n"
+        "~~~markdown\n"
+        "[[invented|Tilde Example]]\n"
+        "~~~\n"
+        "`````markdown\n"
+        "[[invented|Long Fence Example]]\n"
+        "```\n"
+        "[[still-in-long-fence]]\n"
+        "`````\n"
+    )
+
+    sanitized = _sanitize_article_wikilinks(body, {"approved"})
+
+    assert sanitized == (
+        "Keep [[Approved]], [[Wiki/Concepts/APPROVED.md#Heading|Shown]], "
+        "[[approved^block]], [[approved.md]], and [[approved|Alias]].\n"
+        "Drop invented, invented, invented, and Display Text while keeping sibling "
+        "[[approved]].\n\n"
+        "~~~markdown\n"
+        "[[invented|Tilde Example]]\n"
+        "~~~\n"
+        "`````markdown\n"
+        "[[invented|Long Fence Example]]\n"
+        "```\n"
+        "[[still-in-long-fence]]\n"
+        "`````\n"
+    )
+    assert set(extract_wikilinks(sanitized)) == {"approved"}
+
+
+def test_article_wikilink_sanitizer_rescans_nested_and_malformed_aliases():
+    body = (
+        "Nested [[bad|[[evil]]]], malformed [[[[bad]]]], surrounding [[[evil]]], "
+        "and alias [[bad|Display [[evil]] text]]; keep [[approved]], drop [[bad]]."
+    )
+
+    sanitized = _sanitize_article_wikilinks(body, {"approved"})
+
+    assert extract_wikilinks(sanitized) == ["approved"]
+    assert "[[evil]]" not in sanitized
+    assert "[[bad]]" not in sanitized
+    assert "Nested evil" in sanitized
+    assert "keep [[approved]], drop bad" in sanitized
+
+
+def test_article_prompts_bound_existing_concept_allowlist_and_prohibit_links_when_empty():
+    concept = WikiConceptEntry(
+        name="Prompt Contract",
+        status=ConceptStatus.NEW,
+        description="Prompt rules",
+        source_urls=[],
+    )
+    empty_provider = StubProvider(["article"])
+    asyncio.run(
+        _create_article(
+            concept,
+            {},
+            empty_provider,
+            approved_concept_slugs=set(),
+        )
+    )
+
+    assert "No concept slugs are approved" in empty_provider.prompts[0]
+    assert "Do not use any Obsidian wikilinks" in empty_provider.prompts[0]
+
+    bounded_provider = StubProvider(["article"])
+    asyncio.run(
+        _create_article(
+            concept,
+            {},
+            bounded_provider,
+            approved_concept_slugs={f"concept-{index:04d}" for index in range(1000)},
+        )
+    )
+
+    bounded_prompt = bounded_provider.prompts[0]
+    assert len(bounded_prompt) <= ARTICLE_PROMPT_TOTAL_CHARS
+    assert "concept-0000" in bounded_prompt
+    assert "concept-0999" not in bounded_prompt
+
+
+def test_compile_create_write_sanitizes_against_precompile_disk_concepts(test_config):
+    source = _raw_source(slug="wikilink-create", source_url="https://example.com/create")
+    _seed_existing_concept(
+        test_config,
+        slug="approved-existing",
+        title="Approved Existing",
+        body="# Approved Existing\n\n## Overview\n\nExisting.\n",
+    )
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Fresh A",
+                    "status": "new",
+                    "description": "First concurrent concept",
+                    "source_urls": [source.source_url],
+                },
+                {
+                    "name": "Fresh B",
+                    "status": "new",
+                    "description": "Second concurrent concept",
+                    "source_urls": [source.source_url],
+                },
+            ]
+        }
+    )
+    provider = StubProvider(
+        [
+            triage,
+            triage,
+            (
+                "# Fresh A\n\n## Overview\n\n"
+                "Use [[APPROVED-EXISTING|Approved]], not [[fresh-b|Fresh B]] or "
+                "[[kv-caching]]. Nested [[bad|[[evil]]]] and [[[[bad]]]].\n\n"
+                "~~~markdown\n[[invented-tilde-example]]\n~~~\n"
+            ),
+            "# Fresh B\n\n## Overview\n\nFresh B.",
+        ]
+    )
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            existing_concepts=[("approved-existing", "Approved Existing")],
+            max_touches=0,
+        )
+    )
+
+    fresh_a = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+        / "fresh-a.md"
+    ).read_text(encoding="utf-8")
+    assert result.articles_created == 2
+    assert "[[APPROVED-EXISTING|Approved]]" in fresh_a
+    assert "not Fresh B or kv-caching" in fresh_a
+    assert "Nested evil and bad" in fresh_a
+    assert "[[fresh-b" not in fresh_a
+    assert "~~~markdown\n[[invented-tilde-example]]\n~~~" in fresh_a
+    assert extract_wikilinks(fresh_a) == ["approved-existing"]
+    persisted_page = WikiPage(relative_path="fresh-a", text=fresh_a, is_index=False)
+    assert check_broken_wikilinks(
+        [persisted_page], {"approved-existing", "fresh-a", "fresh-b"}
+    ) == []
+    assert all("approved-existing" in prompt for prompt in provider.prompts[2:])
+    assert all("Only use wikilinks whose target" in prompt for prompt in provider.prompts[2:])
+
+
+def test_compile_create_write_sanitizes_model_title_before_frontmatter_and_h1(
+    test_config,
+):
+    source = _raw_source(slug="title-wikilink", source_url="https://example.com/title")
+    model_title = "Fresh [[invented|Readable [[nested]]]]"
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": model_title,
+                    "status": "new",
+                    "description": "Untrusted model title",
+                    "source_urls": [source.source_url],
+                }
+            ]
+        }
+    )
+    provider = StubProvider([triage, "## Overview\n\nArticle body."])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=0,
+        )
+    )
+
+    article_path = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+        / "fresh-inventedreadable-nested.md"
+    )
+    persisted = article_path.read_text(encoding="utf-8")
+    assert result.articles_created == 1
+    assert _extract_frontmatter(persisted)["title"] == "Fresh Readable nested"
+    assert "\n# Fresh Readable nested\n" in persisted
+    assert "[[invented" not in persisted
+    assert "[[nested" not in persisted
+    assert check_broken_wikilinks(
+        [
+            WikiPage(
+                relative_path="fresh-inventedreadable-nested",
+                text=persisted,
+                is_index=False,
+            )
+        ],
+        {"fresh-inventedreadable-nested"},
+    ) == []
+
+
+def test_compile_create_write_sanitizes_after_lone_cr_fence_before_persistence(
+    test_config,
+):
+    source = _raw_source(slug="cr-fence", source_url="https://example.com/cr-fence")
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "CR Fence",
+                    "status": "new",
+                    "description": "Lone CR fence endings",
+                    "source_urls": [source.source_url],
+                }
+            ]
+        }
+    )
+    model_article = (
+        "## Overview\n\nExample:\n"
+        "```text\r"
+        "[[fenced-example]]\r"
+        "```\r"
+        "After [[invented-after-cr|readable fallback]].\r"
+    )
+    assert extract_wikilinks(model_article) == ["invented-after-cr"]
+    provider = StubProvider([triage, model_article])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            max_touches=0,
+        )
+    )
+
+    article_path = (
+        test_config.vault_path
+        / test_config.folders.wiki
+        / test_config.folders.wiki_concepts
+        / "cr-fence.md"
+    )
+    persisted = article_path.read_text(encoding="utf-8")
+    assert result.articles_created == 1
+    assert "[[fenced-example]]" in persisted
+    assert "After readable fallback." in persisted
+    assert extract_wikilinks(persisted) == []
+    assert check_broken_wikilinks(
+        [WikiPage(relative_path="cr-fence", text=persisted, is_index=False)],
+        {"cr-fence"},
+    ) == []
+
+
+def test_compile_update_write_sanitizes_links_and_preserves_readable_markdown(test_config):
+    source = _raw_source(slug="wikilink-update", source_url="https://example.com/update")
+    target_path = _seed_existing_concept(
+        test_config,
+        slug="update-target",
+        title="Human Update Title",
+        body="# Human Update Title\n\n## Overview\n\nOld.\n",
+    )
+    _seed_existing_concept(
+        test_config,
+        slug="approved-related",
+        title="Approved Related",
+        body="# Approved Related\n\n## Overview\n\nRelated.\n",
+    )
+    triage = json.dumps(
+        {
+            "concepts": [
+                {
+                    "name": "Update Target",
+                    "status": "existing:update-target",
+                    "description": "Update existing article",
+                    "source_urls": [source.source_url],
+                    "merge_target": "update-target",
+                }
+            ]
+        }
+    )
+    model_update = (
+        "# Wrong Model Title\n\n## Overview\n\n"
+        "Keep **[[Wiki/Concepts/APPROVED-RELATED.md#Overview|Related]]**, "
+        "replace [[kv-caching|KV caching]] and [[path/linear-attention.md^detail]]. "
+        "Do not reconstruct [[bad|[[evil]]]] or [[[[bad]]]].\n\n"
+        "`````markdown\n"
+        "[[invented-long-fence-example]]\n"
+        "```\n"
+        "[[invented-after-short-run]]\n"
+        "`````\n"
+    )
+    provider = StubProvider([triage, model_update])
+
+    result, _ = asyncio.run(
+        compile_sources(
+            [source],
+            Manifest(),
+            provider,
+            test_config.vault_path,
+            test_config.folders,
+            existing_concepts=[
+                ("approved-related", "Approved Related"),
+                ("update-target", "Human Update Title"),
+            ],
+            max_touches=0,
+        )
+    )
+
+    updated = target_path.read_text(encoding="utf-8")
+    assert result.articles_updated == 1
+    assert "# Human Update Title" in updated
+    assert "**[[Wiki/Concepts/APPROVED-RELATED.md#Overview|Related]]**" in updated
+    assert "replace KV caching and linear-attention." in updated
+    assert "Do not reconstruct evil or bad" in updated
+    assert (
+        "`````markdown\n"
+        "[[invented-long-fence-example]]\n"
+        "```\n"
+        "[[invented-after-short-run]]\n"
+        "`````"
+    ) in updated
+    assert extract_wikilinks(updated) == ["approved-related"]
+    persisted_page = WikiPage(relative_path="update-target", text=updated, is_index=False)
+    assert check_broken_wikilinks(
+        [persisted_page], {"approved-related", "update-target"}
+    ) == []
+    assert "approved-related" in provider.prompts[1]
 
 
 def test_written_concept_enforces_page_contract_and_synchronizes_sources(test_config):

--- a/tests/test_core_linter.py
+++ b/tests/test_core_linter.py
@@ -116,6 +116,43 @@ More text [[another-valid]].
     assert set(links) == {"valid", "another-valid"}
 
 
+def test_extract_wikilinks_uses_commonmark_tilde_and_length_aware_fences():
+    text = """[[before]]
+~~~markdown
+[[inside-tilde]]
+```
+[[still-inside-tilde]]
+~~~
+[[between]]
+`````
+[[inside-long-backtick]]
+```
+[[after-short-interior-run]]
+`````
+[[after]]
+"""
+
+    assert extract_wikilinks(text) == ["before", "between", "after"]
+    assert check_broken_wikilinks(
+        [WikiPage(relative_path="concept", text=text, is_index=False)],
+        {"before", "between", "after"},
+    ) == []
+
+
+def test_extract_wikilinks_requires_valid_matching_closing_fence():
+    text = """~~~~
+[[inside]]
+~~~
+[[after-short-tilde-run]]
+````
+[[after-mismatched-marker]]
+~~~~
+[[outside]]
+"""
+
+    assert extract_wikilinks(text) == ["outside"]
+
+
 def test_extract_wikilinks_case_normalization():
     """Test that links are lowercased."""
     text = "[[FOO]] and [[Bar]]"


### PR DESCRIPTION
## Summary
- freeze a bounded allowlist of disk-existing concepts before triage
- constrain create/update prompts to approved existing concept slugs
- sanitize generated body and title wikilinks before atomic persistence
- preserve approved canonical forms and fenced examples
- convert invented targets to readable text without reconstructing nested links
- align canonical Lint extraction with CommonMark backtick/tilde fences

## Real-world failure fixed
The first OpenRouter compile produced seven links to pages that did not exist, causing seven `broken_wikilink` Lint errors. This change prevents those links at both create and update write seams.

## Validation
- `uv run ruff check`
- `uv run mypy src/vaultmind`
- `uv run pytest` (269 passed)
- offline evaluation passed with zero broken links and zero Lint findings
- package build passed
- adversarial review: PASS after nested-link, fence, title, and CR regressions
