### PR TITLE
Prepare VaultMind v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.2.3 - 2026-07-15
 
 ### Fixed
 
-- Generated concept articles now preserve only wikilinks to approved concept pages that existed on disk before compilation, degrading invented targets to readable text before atomic create or update writes.
+- Generated concept-article create and update titles and bodies now preserve only wikilinks to approved concept pages that existed on disk before compilation, degrading invented links to readable text before atomic writes.
+- Canonical Lint wikilink extraction now follows the same CommonMark backtick and tilde fence rules as generated-article validation.
 
 ## 0.2.2 - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ than into macOS/Homebrew's system Python:
 
 ```bash
 brew install uv                       # Skip if uv is already installed
-uv tool install vaultmind==0.2.2
+uv tool install vaultmind==0.2.3
 uv tool update-shell                  # Restart the terminal if vm is not found
-vm version                            # VaultMind v0.2.2
+vm version                            # VaultMind v0.2.3
 vm init
 ```
 
@@ -299,15 +299,15 @@ See `vm <command> --help` for all flags.
 
 ## Installation
 
-The current PyPI and GitHub release is 0.2.2. Because VaultMind is a CLI
+The current PyPI and GitHub release is 0.2.3. Because VaultMind is a CLI
 application, install it with an isolated tool manager. The recommended method is
 [uv](https://docs.astral.sh/uv/):
 
 ```bash
 brew install uv                       # Skip if uv is already installed
-uv tool install vaultmind==0.2.2
+uv tool install vaultmind==0.2.3
 uv tool update-shell                  # Then restart the terminal if needed
-vm version                            # VaultMind v0.2.2
+vm version                            # VaultMind v0.2.3
 ```
 
 Alternatively, use pipx:
@@ -315,8 +315,8 @@ Alternatively, use pipx:
 ```bash
 brew install pipx
 pipx ensurepath                       # Then restart the terminal if needed
-pipx install vaultmind==0.2.2
-vm version                            # VaultMind v0.2.2
+pipx install vaultmind==0.2.3
+vm version                            # VaultMind v0.2.3
 ```
 
 A plain `pip install vaultmind` can be rejected by Homebrew-managed Python with
@@ -344,7 +344,7 @@ setup, protected-environment approval, release verification, and recovery guidan
 
 The config stores vault paths, folder names, and AI provider preferences. The `.env` stores API keys.
 
-### Runtime provider fallback (v0.2.2)
+### Runtime provider fallback (v0.2.3)
 
 VaultMind supports Anthropic, OpenAI, OpenRouter, and local Ollama at runtime.
 Every completion follows `ai.fallback_chain` in order. VaultMind constructs all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vaultmind"
-version = "0.2.2"
+version = "0.2.3"
 description = "Clip anything into Obsidian. Run vm compile. Ask your living wiki."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vaultmind/__init__.py
+++ b/src/vaultmind/__init__.py
@@ -1,3 +1,3 @@
 """VaultMind — a local-first CLI for an LLM-maintained Obsidian wiki."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -17,16 +17,16 @@ from vaultmind.main import app
 def test_package_and_runtime_versions_are_consistent() -> None:
     project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
 
-    assert project["version"] == "0.2.2"
-    assert __version__ == "0.2.2"
-    assert version("vaultmind") == "0.2.2"
+    assert project["version"] == "0.2.3"
+    assert __version__ == "0.2.3"
+    assert version("vaultmind") == "0.2.3"
 
 
 def test_vm_version_reports_release_version() -> None:
     result = CliRunner().invoke(app, ["version"])
 
     assert result.exit_code == 0
-    assert result.stdout.strip() == "VaultMind v0.2.2"
+    assert result.stdout.strip() == "VaultMind v0.2.3"
 
 
 def _workflow(path: str) -> dict[str, Any]:
@@ -79,7 +79,7 @@ def test_ci_preserves_quality_build_and_dynamic_wheel_smoke() -> None:
     assert "pyproject.toml" in smoke
     assert "tomllib" in smoke
     assert "EXPECTED_VERSION" in smoke
-    assert "VaultMind v0.2.2" not in smoke
+    assert "VaultMind v0.2.3" not in smoke
 
 
 def test_publish_workflow_has_release_and_required_manual_triggers() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -804,7 +804,7 @@ wheels = [
 
 [[package]]
 name = "vaultmind"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- set all release contracts to v0.2.3
- finalize generated-article wikilink validation release notes
- update installation references
- preserve dependency resolution and runtime behavior

## Validation
- Ruff and strict mypy passed
- 269 tests passed
- offline evaluation: zero broken links/Lint findings and zero unchanged calls/writes
- exact v0.2.3 artifacts built and isolated wheel install passed
- adversarial release review: PASS
